### PR TITLE
[FFM-1719] makefile modified for oapi install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,12 @@ $(GOPATH)/bin/gosec:
 	@curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(GOPATH)/bin
 
 
+$(GOPATH)/bin/oapi-codegen:
+	@echo "🔘 Installing oapicodegen ... (`date '+%H:%M:%S'`)"
+	@go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.6.0
+
 PHONY+= tools
-tools: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec $(GOPATH)/bin/goimports
+tools: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec $(GOPATH)/bin/goimports $(GOPATH)/bin/oapi-codegen
 
 PHONY+= update-tools
 update-tools: delete-tools $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec $(GOPATH)/bin/goimports

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/json-iterator/go v1.1.10
-	github.com/labstack/gommon v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/r3labs/sse v0.0.0-20201126193848-34e640891548


### PR DESCRIPTION
OAPI codegen Installation contains 2 steps:
- install runtime lib
- install oapi codegen

if oapi codegen is newer then runtime lib, then services.go will raise errors in code.