### PR TITLE
(FFM-1857) Streaming reconnect

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -96,7 +96,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 
 	go client.setAnalyticsServiceClient(ctx)
 
-	go client.retrieve(ctx)
+	go client.retrieveInitialData(ctx)
 
 	go client.streamConnect()
 
@@ -119,10 +119,8 @@ func (c *CfClient) IsInitialized() (bool, error) {
 	return false, fmt.Errorf("timeout waiting to initialize")
 }
 
-func (c *CfClient) retrieve(ctx context.Context) {
-	// check for first cycle of cron job
-	// for registering stream consumer
-	c.config.Logger.Info("Polling")
+func (c *CfClient) retrieve(ctx context.Context) bool {
+	ok := true
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -131,6 +129,7 @@ func (c *CfClient) retrieve(ctx context.Context) {
 		defer cancel()
 		err := c.retrieveFlags(rCtx)
 		if err != nil {
+			ok = false
 			c.config.Logger.Errorf("error while retrieving flags: %v", err.Error())
 		}
 	}()
@@ -141,12 +140,23 @@ func (c *CfClient) retrieve(ctx context.Context) {
 		defer cancel()
 		err := c.retrieveSegments(rCtx)
 		if err != nil {
-			c.config.Logger.Errorf("error while retrieving segments at startup: %v", err.Error())
+			ok = false
+			c.config.Logger.Errorf("error while retrieving segments: %v", err.Error())
 		}
 	}()
 	wg.Wait()
+	if ok {
+		c.config.Logger.Info("Data poll finished successfully")
+	} else {
+		c.config.Logger.Error("Data poll finished with errors")
+	}
+
+	return ok
+}
+
+func (c *CfClient) retrieveInitialData(ctx context.Context) {
+	c.retrieve(ctx)
 	c.initialized <- true
-	c.config.Logger.Info("Sync run finished")
 }
 
 func (c *CfClient) streamConnect() {
@@ -160,25 +170,22 @@ func (c *CfClient) streamConnect() {
 	defer c.mux.RUnlock()
 	c.config.Logger.Info("Registering SSE consumer")
 	sseClient := sse.NewClient(fmt.Sprintf("%s/stream?cluster=%s", c.config.url, c.clusterIdentifier))
-	conn := stream.NewSSEClient(c.sdkKey, c.token, sseClient, c.config.Cache, c.api, c.config.Logger)
-	err := conn.Connect(c.environmentID)
-	if err != nil {
-		c.streamConnected = false
-		return
-	}
 
-	c.streamConnected = true
-	err = conn.OnDisconnect(func() error {
+	streamErr := func() {
+		c.config.Logger.Error("Stream disconnected. Swapping to polling mode")
 		// Wait one minute before moving to polling
 		time.Sleep(1 * time.Minute)
 		c.mux.RLock()
 		defer c.mux.RUnlock()
 		c.streamConnected = false
-		return nil
-	})
-	if err != nil {
-		c.config.Logger.Errorf("error disconnecting the stream, err: %v", err)
 	}
+	conn := stream.NewSSEClient(c.sdkKey, c.token, sseClient, c.config.Cache, c.api, c.config.Logger, streamErr)
+
+	// Connect kicks off a goroutine that attempts to establish a stream connection
+	// while this is happening we set streamConnected to true - if any errors happen
+	// in this process streamConnected will be set back to false by the streamErr function
+	conn.Connect(c.environmentID)
+	c.streamConnected = true
 }
 
 func (c *CfClient) authenticate(ctx context.Context, target evaluation.Target) {
@@ -291,10 +298,12 @@ func (c *CfClient) pullCronJob(ctx context.Context) {
 		case <-pullingTicker.C:
 			c.mux.RLock()
 			if !c.streamConnected {
-				c.retrieve(ctx)
-				if c.config.enableStream {
+				ok := c.retrieve(ctx)
+				// we should only try and start the stream after the poll succeeded to make sure we get the latest changes
+				if ok && c.config.enableStream {
 					// here stream is enabled but not connected, so we attempt to reconnect
-					go c.streamConnect()
+					c.config.Logger.Info("Attempting to start stream")
+					c.streamConnect()
 				}
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,5 @@ require (
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 )


### PR DESCRIPTION
**What**
For our SDK's the desired functionality if we lose connection is to poll the data directly to collect any updates we missed then re-establish the stream. There were bugs in this area that this pr addresses. 

**Fixes**
1. When running the reconnect poll via the `retrieve` function it included logic only required on startup i.e. pushing a value to the `c.initialized` channel - this meant when called later nobody was listening on the channel and the thread would hang forever. 
2. We didn't check that the data poll succeeded before trying to restart the stream
3. We didn't run the `onDisconnect` logic if the stream failed to start up - only if it disconnected, this meant if this path was hit the stream wouldn't start but `c.streamConnected` would still be set to true preventing any new streams starting to replace it
4. The sse library we use has by default an `ExponentialBackoff ` strategy where it continually tries to reconnect to the stream - because we have our own disconnect logic to poll then start a new stream we don't want this - otherwise we'd end up with 2 streams listening for the same events so we set it to `StopBackOff` strategy where it doesn't attempt to re-establish the connection and we can handle it
5. In our restart logic `c.streamConnect()` was started as a goroutine - there was no need for this and it defeated the purpose of the rLock we used to control access to this block of code to prevent multiple threads trying to poll/start the stream
6. Added extra logging around the stream disconnecting -> moving to polling mode-> back to streaming mode

**Testing**
Simulate the stream being lost and test that it reconnects after a successful poll, the simplest way to do this is turn off your wifi and wait 5 minutes