### PR TITLE
(FFM-1815) Lower metrics log level

### DIFF
--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -224,7 +224,7 @@ func (as *AnalyticsService) sendDataAndResetCache(ctx context.Context) {
 	if err != nil {
 		as.logger.Errorf(err.Error())
 	}
-	as.logger.Info(string(jsonData))
+	as.logger.Debug(string(jsonData))
 
 	if as.metricsClient != nil {
 		mClient := *as.metricsClient
@@ -242,7 +242,7 @@ func (as *AnalyticsService) sendDataAndResetCache(ctx context.Context) {
 			return
 		}
 
-		as.logger.Info("Metrics sent to server")
+		as.logger.Debug("Metrics sent to server")
 	} else {
 		as.logger.Warn("metrics client is not set")
 	}


### PR DESCRIPTION
**What**
Lower metrics log level to debug

**Why**
We have a lot of valuable logs at info level e.g. SSE event coming in, updates on polling progress which I'd like to see but I don't want my logs cluttered by these two metric logs printing every minute.
This is especially a problem where we can have 10 sdk's running in parallel and would like the logs to be silent unless theres an error or an event happens