### PR TITLE
(FFM-1814) Increase IsInitialized timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,12 +108,12 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 }
 
 // IsInitialized determines if the client is ready to be used.  This is true if it has both authenticated
-// and successfully retrieved flags.  If it takes longer than 30 seconds the call will timeout and return an error.
+// and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
 func (c *CfClient) IsInitialized() (bool, error) {
 	select {
 	case <-c.initialized:
 		return true, nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(1 * time.Minute):
 		break
 	}
 	return false, fmt.Errorf("timeout waiting to initialize")


### PR DESCRIPTION
**What**
Increase the wait time for the sdk IsInitialized call to 1 minute

**Why**
The timeout for our initial data poll is 1 minute so we should match it here and not let sdk consumers think our setup has failed before it actually has. 