### PR TITLE
(MAINT) Remove 1 minute timer on disconnect

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -175,8 +175,6 @@ func (c *CfClient) streamConnect() {
 
 	streamErr := func() {
 		c.config.Logger.Error("Stream disconnected. Swapping to polling mode")
-		// Wait one minute before moving to polling
-		time.Sleep(1 * time.Minute)
 		c.mux.RLock()
 		defer c.mux.RUnlock()
 		c.streamConnected = false


### PR DESCRIPTION
**Issue**
We had a 1 minute wait in the streamErr function - this could cause some unexpected behaviour when clashing with the poll interval timer e.g. 
Minute 1: Poll interval runs -> fails to setup stream -> kicks off streamErr func
Minute 2: Poll interval runs -> sets up stream correctly -> streamErr wait finishes which resets streamConnected bool to false
Minute 3: Poll interval runs -> sets up a second stream because it thinks streamConnected is false

The bigger underlying issue I see here is that we rely on getting and setting booleans to represent if a stream is connected or not rather than having an actual stream object that we can check for health and guarantee there will only be the one in the system. This would require a larger refactor though so this should mitigate the bug for now