### PR TITLE
(FFM-1842) Add IsStreamConnected func

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -103,6 +103,11 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 	return client, nil
 }
 
+// IsStreamConnected determines if the stream is currently connected
+func (c *CfClient) IsStreamConnected() bool {
+	return c.streamConnected
+}
+
 // IsInitialized determines if the client is ready to be used.  This is true if it has both authenticated
 // and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
 func (c *CfClient) IsInitialized() (bool, error) {


### PR DESCRIPTION
**What**
Add a way for consumers to check if the stream is connected

**Why**
We'd like to consume this in the ff-proxy for the healthcheck endpoint