### PR TITLE
FFM-2096 Add Interface for hooking into SSE Events

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -184,12 +184,12 @@ func (c *CfClient) streamConnect() {
 		defer c.mux.RUnlock()
 		c.streamConnected = false
 	}
-	conn := stream.NewSSEClient(c.sdkKey, c.token, sseClient, c.config.Cache, c.api, c.config.Logger, streamErr)
+	conn := stream.NewSSEClient(c.sdkKey, c.token, sseClient, c.config.Cache, c.api, c.config.Logger, streamErr, c.config.eventStreamListener)
 
 	// Connect kicks off a goroutine that attempts to establish a stream connection
 	// while this is happening we set streamConnected to true - if any errors happen
 	// in this process streamConnected will be set back to false by the streamErr function
-	conn.Connect(c.environmentID)
+	conn.Connect(c.environmentID, c.sdkKey)
 	c.streamConnected = true
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -163,7 +163,7 @@ func (c *CfClient) retrieve(ctx context.Context) bool {
 	return ok
 }
 
-func (c *CfClient) streamConnect() {
+func (c *CfClient) streamConnect(ctx context.Context) {
 	// we only ever want one stream to be setup - other threads must wait before trying to establish a connection
 	c.streamConnectedLock.Lock()
 	defer c.streamConnectedLock.Unlock()
@@ -189,7 +189,7 @@ func (c *CfClient) streamConnect() {
 	// Connect kicks off a goroutine that attempts to establish a stream connection
 	// while this is happening we set streamConnected to true - if any errors happen
 	// in this process streamConnected will be set back to false by the streamErr function
-	conn.Connect(c.environmentID, c.sdkKey)
+	conn.Connect(ctx, c.environmentID, c.sdkKey)
 	c.streamConnected = true
 }
 
@@ -307,7 +307,7 @@ func (c *CfClient) pullCronJob(ctx context.Context) {
 			if ok && c.config.enableStream {
 				// here stream is enabled but not connected, so we attempt to reconnect
 				c.config.Logger.Info("Attempting to start stream")
-				c.streamConnect()
+				c.streamConnect(ctx)
 			}
 		}
 		c.mux.RUnlock()

--- a/client/config.go
+++ b/client/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/harness/ff-golang-server-sdk/evaluation"
+	"github.com/harness/ff-golang-server-sdk/stream"
 
 	"github.com/harness/ff-golang-server-sdk/cache"
 	"github.com/harness/ff-golang-server-sdk/logger"
@@ -13,16 +14,17 @@ import (
 )
 
 type config struct {
-	url          string
-	eventsURL    string
-	pullInterval uint // in minutes
-	Cache        cache.Cache
-	Store        storage.Storage
-	Logger       logger.Logger
-	httpClient   *http.Client
-	enableStream bool
-	enableStore  bool
-	target       evaluation.Target
+	url                 string
+	eventsURL           string
+	pullInterval        uint // in minutes
+	Cache               cache.Cache
+	Store               storage.Storage
+	Logger              logger.Logger
+	httpClient          *http.Client
+	enableStream        bool
+	enableStore         bool
+	target              evaluation.Target
+	eventStreamListener stream.EventStreamListener
 }
 
 func newDefaultConfig() *config {

--- a/client/options.go
+++ b/client/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 	"github.com/harness/ff-golang-server-sdk/logger"
 	"github.com/harness/ff-golang-server-sdk/storage"
+	"github.com/harness/ff-golang-server-sdk/stream"
 )
 
 // ConfigOption is used as return value for advanced client configuration
@@ -86,5 +87,13 @@ func WithHTTPClient(client *http.Client) ConfigOption {
 func WithTarget(target evaluation.Target) ConfigOption {
 	return func(config *config) {
 		config.target = target
+	}
+}
+
+// WithEventStreamListener configures the SDK to forward Events from the Feature
+// Flag server to the passed EventStreamListener
+func WithEventStreamListener(cs stream.EventStreamListener) ConfigOption {
+	return func(config *config) {
+		config.eventStreamListener = cs
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -92,8 +92,8 @@ func WithTarget(target evaluation.Target) ConfigOption {
 
 // WithEventStreamListener configures the SDK to forward Events from the Feature
 // Flag server to the passed EventStreamListener
-func WithEventStreamListener(cs stream.EventStreamListener) ConfigOption {
+func WithEventStreamListener(e stream.EventStreamListener) ConfigOption {
 	return func(config *config) {
-		config.eventStreamListener = cs
+		config.eventStreamListener = e
 	}
 }

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/harness/ff-golang-server-sdk/cache"
@@ -17,11 +18,12 @@ import (
 
 // SSEClient is Server Send Event object
 type SSEClient struct {
-	api           rest.ClientWithResponsesInterface
-	client        *sse.Client
-	cache         cache.Cache
-	logger        logger.Logger
-	onStreamError func()
+	api                 rest.ClientWithResponsesInterface
+	client              *sse.Client
+	cache               cache.Cache
+	logger              logger.Logger
+	onStreamError       func()
+	eventStreamListener EventStreamListener
 }
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -35,6 +37,7 @@ func NewSSEClient(
 	api rest.ClientWithResponsesInterface,
 	logger logger.Logger,
 	onStreamError func(),
+	eventStreamListener EventStreamListener,
 ) *SSEClient {
 	client.Headers["Authorization"] = fmt.Sprintf("Bearer %s", token)
 	client.Headers["API-Key"] = apiKey
@@ -42,17 +45,18 @@ func NewSSEClient(
 		onStreamError()
 	})
 	sseClient := &SSEClient{
-		client:        client,
-		cache:         cache,
-		api:           api,
-		logger:        logger,
-		onStreamError: onStreamError,
+		client:              client,
+		cache:               cache,
+		api:                 api,
+		logger:              logger,
+		onStreamError:       onStreamError,
+		eventStreamListener: eventStreamListener,
 	}
 	return sseClient
 }
 
 // Connect will subscribe to SSE stream
-func (c *SSEClient) Connect(environment string) {
+func (c *SSEClient) Connect(environment string, apiKey string) {
 	c.logger.Infof("Start subscribing to Stream")
 	// don't use the default exponentialBackoff strategy - we have our own disconnect logic
 	// of polling the service then re-establishing a new stream once we can connect
@@ -61,6 +65,8 @@ func (c *SSEClient) Connect(environment string) {
 	go func() {
 		err := c.client.Subscribe("*", func(msg *sse.Event) {
 			c.logger.Infof("Event received: %s", msg.Data)
+
+			wg := &sync.WaitGroup{}
 
 			cfMsg := Message{}
 			if len(msg.Data) > 0 {
@@ -76,16 +82,25 @@ func (c *SSEClient) Connect(environment string) {
 					// and subscribe to that event
 					switch cfMsg.Event {
 					case dto.SseDeleteEvent:
+						wg.Add(1)
+
 						go func(identifier string) {
+							defer wg.Done()
+
 							c.cache.Remove(dto.Key{
 								Type: dto.KeyFeature,
 								Name: identifier,
 							})
 						}(cfMsg.Identifier)
+
 					case dto.SsePatchEvent, dto.SseCreateEvent:
 						fallthrough
 					default:
+						wg.Add(1)
+
 						go func(env, identifier string) {
+							defer wg.Done()
+
 							ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 							defer cancel()
 							response, err := c.api.GetFeatureConfigByIdentifierWithResponse(ctx, env, identifier)
@@ -101,20 +116,30 @@ func (c *SSEClient) Connect(environment string) {
 							}
 						}(environment, cfMsg.Identifier)
 					}
+
 				case dto.KeySegment:
 					// need open client spec change
 					switch cfMsg.Event {
 					case dto.SseDeleteEvent:
+						wg.Add(1)
+
 						go func(identifier string) {
+							defer wg.Done()
+
 							c.cache.Remove(dto.Key{
 								Type: dto.KeySegment,
 								Name: identifier,
 							})
 						}(cfMsg.Identifier)
+
 					case dto.SsePatchEvent, dto.SseCreateEvent:
 						fallthrough
 					default:
+						wg.Add(1)
+
 						go func(env, identifier string) {
+							defer wg.Done()
+
 							ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 							defer cancel()
 							response, err := c.api.GetSegmentByIdentifierWithResponse(ctx, env, identifier)
@@ -129,6 +154,19 @@ func (c *SSEClient) Connect(environment string) {
 								}, response.JSON200.Convert())
 							}
 						}(environment, cfMsg.Identifier)
+					}
+				}
+
+				if c.eventStreamListener != nil {
+					sendWithTimeout := func() error {
+						ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+						defer cancel()
+						return c.eventStreamListener.Pub(ctx, Event{APIKey: apiKey, Environment: environment, Event: msg})
+					}
+
+					wg.Wait()
+					if err := sendWithTimeout(); err != nil {
+						c.logger.Errorf("error while forwarding SSE Event to change stream: %s", err)
 					}
 				}
 			}

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -3,7 +3,6 @@ package stream
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/harness/ff-golang-server-sdk/cache"
@@ -56,124 +55,169 @@ func NewSSEClient(
 }
 
 // Connect will subscribe to SSE stream
-func (c *SSEClient) Connect(environment string, apiKey string) {
+func (c *SSEClient) Connect(ctx context.Context, environment string, apiKey string) {
+	go func() {
+		for event := range orDone(ctx, c.subscribe(ctx, environment, apiKey)) {
+			c.handleEvent(event)
+		}
+	}()
+}
+
+// Connect will subscribe to SSE stream
+func (c *SSEClient) subscribe(ctx context.Context, environment string, apiKey string) <-chan Event {
 	c.logger.Infof("Start subscribing to Stream")
 	// don't use the default exponentialBackoff strategy - we have our own disconnect logic
 	// of polling the service then re-establishing a new stream once we can connect
 	c.client.ReconnectStrategy = &backoff.StopBackOff{}
 	// it is blocking operation, it needs to go in go routine
+
+	out := make(chan Event)
 	go func() {
-		err := c.client.Subscribe("*", func(msg *sse.Event) {
+		defer close(out)
+
+		err := c.client.SubscribeWithContext(ctx, "*", func(msg *sse.Event) {
 			c.logger.Infof("Event received: %s", msg.Data)
 
-			wg := &sync.WaitGroup{}
-
-			cfMsg := Message{}
-			if len(msg.Data) > 0 {
-				err := json.Unmarshal(msg.Data, &cfMsg)
-				if err != nil {
-					c.logger.Errorf("%s", err.Error())
-					return
-				}
-
-				switch cfMsg.Domain {
-				case dto.KeyFeature:
-					// maybe is better to send event on memory bus that we get new message
-					// and subscribe to that event
-					switch cfMsg.Event {
-					case dto.SseDeleteEvent:
-						wg.Add(1)
-
-						go func(identifier string) {
-							defer wg.Done()
-
-							c.cache.Remove(dto.Key{
-								Type: dto.KeyFeature,
-								Name: identifier,
-							})
-						}(cfMsg.Identifier)
-
-					case dto.SsePatchEvent, dto.SseCreateEvent:
-						fallthrough
-					default:
-						wg.Add(1)
-
-						go func(env, identifier string) {
-							defer wg.Done()
-
-							ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-							defer cancel()
-							response, err := c.api.GetFeatureConfigByIdentifierWithResponse(ctx, env, identifier)
-							if err != nil {
-								c.logger.Errorf("error while pulling flag, err: %s", err.Error())
-								return
-							}
-							if response.JSON200 != nil {
-								c.cache.Set(dto.Key{
-									Type: dto.KeyFeature,
-									Name: identifier,
-								}, *response.JSON200.Convert())
-							}
-						}(environment, cfMsg.Identifier)
-					}
-
-				case dto.KeySegment:
-					// need open client spec change
-					switch cfMsg.Event {
-					case dto.SseDeleteEvent:
-						wg.Add(1)
-
-						go func(identifier string) {
-							defer wg.Done()
-
-							c.cache.Remove(dto.Key{
-								Type: dto.KeySegment,
-								Name: identifier,
-							})
-						}(cfMsg.Identifier)
-
-					case dto.SsePatchEvent, dto.SseCreateEvent:
-						fallthrough
-					default:
-						wg.Add(1)
-
-						go func(env, identifier string) {
-							defer wg.Done()
-
-							ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-							defer cancel()
-							response, err := c.api.GetSegmentByIdentifierWithResponse(ctx, env, identifier)
-							if err != nil {
-								c.logger.Errorf("error while pulling segment, err: %s", err.Error())
-								return
-							}
-							if response.JSON200 != nil {
-								c.cache.Set(dto.Key{
-									Type: dto.KeySegment,
-									Name: identifier,
-								}, response.JSON200.Convert())
-							}
-						}(environment, cfMsg.Identifier)
-					}
-				}
-
-				if c.eventStreamListener != nil {
-					sendWithTimeout := func() error {
-						ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer cancel()
-						return c.eventStreamListener.Pub(ctx, Event{APIKey: apiKey, Environment: environment, Event: msg})
-					}
-
-					wg.Wait()
-					if err := sendWithTimeout(); err != nil {
-						c.logger.Errorf("error while forwarding SSE Event to change stream: %s", err)
-					}
-				}
+			if len(msg.Data) <= 0 {
+				return
 			}
+
+			event := Event{
+				APIKey:      apiKey,
+				Environment: environment,
+				SSEEvent:    msg,
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case out <- event:
+			}
+
 		})
 		if err != nil {
 			c.logger.Errorf("Error initializing stream: %s", err.Error())
 			c.onStreamError()
 		}
 	}()
+
+	return out
+}
+
+func (c *SSEClient) handleEvent(event Event) {
+	cfMsg := Message{}
+	err := json.Unmarshal(event.SSEEvent.Data, &cfMsg)
+	if err != nil {
+		c.logger.Errorf("%s", err.Error())
+		return
+	}
+
+	switch cfMsg.Domain {
+	case dto.KeyFeature:
+		// maybe is better to send event on memory bus that we get new message
+		// and subscribe to that event
+		switch cfMsg.Event {
+		case dto.SseDeleteEvent:
+
+			c.cache.Remove(dto.Key{
+				Type: dto.KeyFeature,
+				Name: cfMsg.Identifier,
+			})
+
+		case dto.SsePatchEvent, dto.SseCreateEvent:
+			fallthrough
+		default:
+			updateWithTimeout := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+				defer cancel()
+
+				response, err := c.api.GetFeatureConfigByIdentifierWithResponse(ctx, event.Environment, cfMsg.Identifier)
+				if err != nil {
+					c.logger.Errorf("error while pulling flag, err: %s", err.Error())
+					return
+				}
+
+				if response.JSON200 != nil {
+					c.cache.Set(dto.Key{
+						Type: dto.KeyFeature,
+						Name: cfMsg.Identifier,
+					}, *response.JSON200.Convert())
+				}
+			}
+
+			updateWithTimeout()
+		}
+
+	case dto.KeySegment:
+		// need open client spec change
+		switch cfMsg.Event {
+		case dto.SseDeleteEvent:
+
+			c.cache.Remove(dto.Key{
+				Type: dto.KeySegment,
+				Name: cfMsg.Identifier,
+			})
+
+		case dto.SsePatchEvent, dto.SseCreateEvent:
+			fallthrough
+		default:
+			updateWithTimeout := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+				defer cancel()
+
+				response, err := c.api.GetSegmentByIdentifierWithResponse(ctx, event.Environment, cfMsg.Identifier)
+				if err != nil {
+					c.logger.Errorf("error while pulling segment, err: %s", err.Error())
+					return
+				}
+				if response.JSON200 != nil {
+					c.cache.Set(dto.Key{
+						Type: dto.KeySegment,
+						Name: cfMsg.Identifier,
+					}, response.JSON200.Convert())
+				}
+			}
+			updateWithTimeout()
+		}
+	}
+
+	if c.eventStreamListener != nil {
+		sendWithTimeout := func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			return c.eventStreamListener.Pub(ctx, Event{APIKey: event.APIKey, Environment: event.Environment, SSEEvent: event.SSEEvent})
+		}
+
+		if err := sendWithTimeout(); err != nil {
+			c.logger.Errorf("error while forwarding SSE Event to change stream: %s", err)
+		}
+	}
+}
+
+// orDone is a helper that encapsulates the logic for reading from a channel
+// whilst waiting for a cancellation.
+func orDone(ctx context.Context, c <-chan Event) <-chan Event {
+	out := make(chan Event)
+
+	go func() {
+		defer close(out)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case cp, ok := <-c:
+				if !ok {
+					return
+				}
+
+				select {
+				case <-ctx.Done():
+				case out <- cp:
+				}
+			}
+		}
+	}()
+
+	return out
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,7 +1,30 @@
 package stream
 
+import (
+	"context"
+
+	"github.com/r3labs/sse"
+)
+
 // Connection is simple interface for streams
 type Connection interface {
 	Connect(environment string) error
 	OnDisconnect(func() error) error
+}
+
+// EventStreamListener provides a way to hook in to the SSE Events that the SDK
+// recieves from the FeatureFlags server and forward them on to another type.
+type EventStreamListener interface {
+	// Pub publishes an event from the SDK to your Listener
+	Pub(ctx context.Context, event Event) error
+}
+
+// Event defines the structure of an event that gets sent to a EventStreamListener
+type Event struct {
+	// APIKey is the SDKs API Key
+	APIKey string
+	// Environment is the ID of the environment that the event occured for
+	Environment string
+	// Event is the SSEEvent that was sent from the FeatureFlags server to the SDK
+	Event *sse.Event
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -15,7 +15,8 @@ type Connection interface {
 // EventStreamListener provides a way to hook in to the SSE Events that the SDK
 // recieves from the FeatureFlags server and forward them on to another type.
 type EventStreamListener interface {
-	// Pub publishes an event from the SDK to your Listener
+	// Pub publishes an event from the SDK to your Listener. Pub should implement
+	// any backoff/retry logic as this is not handled in the SDK.
 	Pub(ctx context.Context, event Event) error
 }
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -26,6 +26,6 @@ type Event struct {
 	APIKey string
 	// Environment is the ID of the environment that the event occured for
 	Environment string
-	// Event is the SSEEvent that was sent from the FeatureFlags server to the SDK
-	Event *sse.Event
+	// SSEEvent is the SSEEvent that was sent from the FeatureFlags server to the SDK
+	SSEEvent *sse.Event
 }


### PR DESCRIPTION
**What**

- Creates an Interface that clients can implement in order or receive the SSE Events that the SDK gets from Feature Flags
- Adds an option func so clients can pass their own EventStreamListener in, default behaviour is to not have one. 

**Why**

In order to implement streaming in the Proxy we need to be able to get the SSE events after the SDK has updated the cache. This change only forwards the Event to the EventListener after the cache has been updated.

**Testing**

Did the following locally
- Created a basic EventListener in the Proxy and passed it in to the embedded SDK using `WithEventStreamListener`. 
- Changed the Proxy stream handler to just return the Grip Control headers for pushpin
- Ran the Proxy and pointed and SDK at it that was running in streaming mode
- Toggled flags on/off and the SDK got the event and then fetched the new value from the Proxy's cache

Basic Event Listener
```go
type EventListener struct {
	gpc *gripcontrol.GripPubControl
}

func NewEventListener() EventListener {
	gpc := gripcontrol.NewGripPubControl([]map[string]interface{}{
		{
			"control_uri": "http://localhost:5561",
		},
	})
	return EventListener{gpc}
}

func (e EventListener) Pub(ctx context.Context, event stream.Event) error {
	fmt.Println("Got SSE Event From SDK")

	h := hash.NewSha256()
	channel := h.Hash(event.APIKey)

	content := fmt.Sprintf("event: *\ndata: %s\n\n", event.Event.Data)
	if err := e.gpc.PublishHttpStream(channel, content, "", ""); err != nil {
		fmt.Printf("Error sending data: %s, to pushpin with err %s", event.Event.Data, err)
	}

	fmt.Printf("Pushing event to pushpin %+v", event)
	return nil
}
```

Basic Stream Handler

```go
h.router.GET("/stream", func(c echo.Context) error {
	w := c.Response().Writer
	apiKey := c.Request().Header.Get("API-Key")
	h := hash.NewSha256()

	w.Header().Add("Content-Type", "text/event-stream")
	w.Header().Add("Grip-Hold", "stream")
	w.Header().Add("Grip-Channel", h.Hash(apiKey))
	w.Header().Add("Grip-Keep-Alive", "format=cstring,timeout=30")

	return nil
})
```

**Update**
After the refactor I got my Proxy to use the latest commit on this branch, reran the same manual tests and streaming still works as expected