### PR TITLE
[FFM-2217]: Evaluation returning wrong result with multiple segments

### DIFF
--- a/evaluation/segment.go
+++ b/evaluation/segment.go
@@ -107,9 +107,9 @@ type Segments map[string]*Segment
 // Evaluate through all segments based on target input
 func (s Segments) Evaluate(target *Target) bool {
 	for _, segment := range s {
-		if !segment.Evaluate(target) {
-			return false
+		if segment.Evaluate(target) {
+			return true
 		}
 	}
-	return true
+	return false
 }

--- a/evaluation/segment_test.go
+++ b/evaluation/segment_test.go
@@ -51,3 +51,67 @@ func TestSegment_Evaluate(t *testing.T) {
 		})
 	}
 }
+
+func TestSegments_Evaluate(t *testing.T) {
+	f := false
+	m := make(map[string]interface{})
+	m["email"] = "john@doe.com"
+	target := Target{
+		Identifier: "john",
+		Anonymous:  &f,
+		Attributes: &m,
+	}
+
+	tests := map[string]struct {
+		segments Segments
+		target   Target
+		want     bool
+	}{
+		"test target included by segment alpha returns true": {
+			segments: Segments{"alpha": {Identifier: "alpha", Included: []string{target.Identifier}}},
+			target:   target,
+			want:     true,
+		},
+		"test target not included segment alpha, but included in beta returns true": {
+			segments: Segments{
+				"alpha": {Identifier: "alpha", Included: []string{}},
+				"beta":  {Identifier: "beta", Included: []string{target.Identifier}},
+			},
+			target: target,
+			want:   true,
+		},
+		"test target not included segment alpha, and not included in beta returns false": {
+			segments: Segments{
+				"alpha": {Identifier: "alpha", Included: []string{}},
+				"beta":  {Identifier: "beta", Included: []string{}},
+			},
+			target: target,
+			want:   false,
+		},
+		"test target included segment alpha, and excluded in beta returns true": {
+			segments: Segments{
+				"alpha": {Identifier: "alpha", Included: []string{target.Identifier}},
+				"beta":  {Identifier: "beta", Excluded: []string{target.Identifier}},
+			},
+			target: target,
+			want:   true,
+		},
+		"test target excluded from segment alpha, and included in beta returns true": {
+			segments: Segments{
+				"alpha": {Identifier: "alpha", Excluded: []string{target.Identifier}},
+				"beta":  {Identifier: "beta", Included: []string{target.Identifier}},
+			},
+			target: target,
+			want:   true,
+		},
+	}
+	for name, tt := range tests {
+		val := tt
+		t.Run(name, func(t *testing.T) {
+			s := val.segments
+			if got := s.Evaluate(&val.target); got != val.want {
+				t.Errorf("Evaluate() = %v, want %v", got, val.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What:
Segments evaluation had two problems:
 1) It returned false if any segment evaluate returned false (even if segment was not part of the clause)
 2) It evaluated the target in segmentMatch clause against all segments, where it should only evaluate against
   the segments defined by the clause.

Evaluation Percentage Rollout was also distributing values incorrectly when there were more than
two variations.

## Testing
Updated unit tests to ensure segment Evaluation performed as expected