### PR TITLE
(FFM-1750) Get connected cluster

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,6 +108,11 @@ func (c *CfClient) IsStreamConnected() bool {
 	return c.streamConnected
 }
 
+// GetClusterIdentifier returns the cluster identifier we're connected to
+func (c *CfClient) GetClusterIdentifier() string {
+	return c.clusterIdentifier
+}
+
 // IsInitialized determines if the client is ready to be used.  This is true if it has both authenticated
 // and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
 func (c *CfClient) IsInitialized() (bool, error) {


### PR DESCRIPTION
**Changes**
Adds the ability to get the connected cluster id

**Why**
The proxy needs to know what cluster we're connected to to forward on some data, we can grab this from the embedded go sdk easily