### PR TITLE
(FFM-2513) Add cluster identifier to metrics requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -284,8 +284,9 @@ func (c *CfClient) authenticate(ctx context.Context, target evaluation.Target) e
 		return err
 	}
 
-	merticsClient, err := metricsclient.NewClientWithResponses(c.config.eventsURL,
+	metricsClient, err := metricsclient.NewClientWithResponses(c.config.eventsURL,
 		metricsclient.WithRequestEditorFn(bearerTokenProvider.Intercept),
+		metricsclient.WithRequestEditorFn(c.InterceptAddCluster),
 		metricsclient.WithHTTPClient(http.DefaultClient),
 	)
 	if err != nil {
@@ -293,7 +294,7 @@ func (c *CfClient) authenticate(ctx context.Context, target evaluation.Target) e
 	}
 
 	c.api = restClient
-	c.metricsapi = merticsClient
+	c.metricsapi = metricsClient
 	c.config.Logger.Info("Authentication complete")
 	close(c.authenticated)
 	return nil


### PR DESCRIPTION
**Issue**
Metrics weren't working for prod-2 accounts. This is because the clusterIdentifier wasn't being set for metrics requests like it is for client requests (see line 280 - a few lines above my changes in this pr).

**Fix**
Send the cluster identifier 

**Testing**
Tested against prod-1 and prod-2 accounts, working as expected