### PR TITLE
FFM-1821 - Prerequisite rules not working on ff-server

### DIFF
--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -68,19 +68,19 @@ func TestFeatureConfig_JsonVariation(t *testing.T) {
 	}{
 		{
 			name:          "Test on variation returned when flag is on",
-			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOn, nil, nil),
 			want:          on,
 			wantErr:       false,
 		},
 		{
 			name:          "Test off variation returned when flag is off",
-			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOff, nil),
+			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOff, nil, nil),
 			want:          off,
 			wantErr:       false,
 		},
 		{
 			name:          "Test error returned when invalid default serve is provided",
-			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, other, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, other, FeatureStateOn, nil, nil),
 			want:          Variation{},
 			wantErr:       true,
 		},
@@ -128,19 +128,19 @@ func TestFeatureConfig_StringVariation(t *testing.T) {
 	}{
 		{
 			name:          "Test on variation returned when flag is on",
-			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOn, nil, nil),
 			want:          on,
 			wantErr:       false,
 		},
 		{
 			name:          "Test off variation returned when flag is off",
-			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOff, nil),
+			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOff, nil, nil),
 			want:          off,
 			wantErr:       false,
 		},
 		{
 			name:          "Test error returned when invalid default serve is provided",
-			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, other, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, other, FeatureStateOn, nil, nil),
 			want:          Variation{},
 			wantErr:       true,
 		},
@@ -188,19 +188,19 @@ func TestFeatureConfig_NumberVariation(t *testing.T) {
 	}{
 		{
 			name:          "Test on variation returned when flag is on",
-			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOn, nil, nil),
 			want:          on,
 			wantErr:       false,
 		},
 		{
 			name:          "Test off variation returned when flag is off",
-			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOff, nil),
+			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOff, nil, nil),
 			want:          off,
 			wantErr:       false,
 		},
 		{
 			name:          "Test error returned when invalid default serve is provided",
-			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, other, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, other, FeatureStateOn, nil, nil),
 			want:          Variation{},
 			wantErr:       true,
 		},
@@ -248,19 +248,19 @@ func TestFeatureConfig_IntVariation(t *testing.T) {
 	}{
 		{
 			name:          "Test on variation returned when flag is on",
-			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOn, nil, nil),
 			want:          on,
 			wantErr:       false,
 		},
 		{
 			name:          "Test off variation returned when flag is off",
-			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOff, nil),
+			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOff, nil, nil),
 			want:          off,
 			wantErr:       false,
 		},
 		{
 			name:          "Test error returned when invalid default serve is provided",
-			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, other, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, other, FeatureStateOn, nil, nil),
 			want:          Variation{},
 			wantErr:       true,
 		},
@@ -434,7 +434,7 @@ func makeIdentifierRule(values []string, operator, variationToServe string) []Se
 	return []ServingRule{rule}
 }
 
-func makeFeatureConfig(name, kind string, variation1, variation2, defaultServe Variation, state FeatureState, rules []ServingRule) FeatureConfig {
+func makeFeatureConfig(name, kind string, variation1, variation2, defaultServe Variation, state FeatureState, rules []ServingRule, prereqs []Prerequisite) FeatureConfig {
 
 	return FeatureConfig{
 		DefaultServe: Serve{
@@ -445,7 +445,7 @@ func makeFeatureConfig(name, kind string, variation1, variation2, defaultServe V
 		Kind:                 kind,
 		OffVariation:         variation2.Identifier,
 		Rules:                rules,
-		Prerequisites:        nil,
+		Prerequisites:        prereqs,
 		Project:              "default",
 		State:                state,
 		VariationToTargetMap: nil,
@@ -498,25 +498,25 @@ func TestFeatureConfig_Evaluate(t *testing.T) {
 	}{
 		{
 			name:          "Test Bool FeatureConfig with no rules serves variation onBool when on",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil),
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil, nil),
 			args:          args{&target},
 			want:          Evaluation{Flag: boolFlagName, Variation: onBool},
 			wantErr:       false},
 		{
 			name:          "Test Bool FeatureConfig Evaluate with no rules serves variation offBool when off",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOff, nil),
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOff, nil, nil),
 			args:          args{&target},
 			want:          Evaluation{Flag: boolFlagName, Variation: offBool},
 			wantErr:       false},
 		{
 			name:          "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves offBool on match when flag on",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{harness}, equalOperator, offBool.Identifier)),
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{harness}, equalOperator, offBool.Identifier), nil),
 			args:          args{&target},
 			want:          Evaluation{Flag: boolFlagName, Variation: offBool},
 			wantErr:       false},
 		{
 			name:          "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves onBool on non-match when flag on",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{"foobar"}, equalOperator, offBool.Identifier)),
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{"foobar"}, equalOperator, offBool.Identifier), nil),
 			args:          args{&target},
 			want:          Evaluation{Flag: boolFlagName, Variation: onBool},
 			wantErr:       false},
@@ -526,6 +526,90 @@ func TestFeatureConfig_Evaluate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fc := tc.featureConfig
 			got, err := fc.Evaluate(tc.args.target)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestFeatureConfig_EvaluateWithPreReqFlags(t *testing.T) {
+	f := false
+	harness := "Harness"
+	m := make(map[string]interface{})
+	m["email"] = "john@doe.com"
+
+	boolFlagName := "SimpleBool"
+
+	onBool := Variation{
+		Name:       stringPtr("On"),
+		Value:      "true",
+		Identifier: "on",
+	}
+
+	offBool := Variation{
+		Name:       stringPtr("Off"),
+		Value:      "false",
+		Identifier: "off",
+	}
+
+	target := Target{
+		Identifier: harness,
+		Anonymous:  &f,
+		Attributes: &m,
+	}
+
+	prereqFooTrue := Prerequisite{Feature: "Foo", Variations: []string{"true"}}
+
+	type args struct {
+		target            *Target
+		prerequisiteFlags map[string]FeatureConfig
+	}
+	tests := []struct {
+		name          string
+		featureConfig FeatureConfig
+		args          args
+		want          Evaluation
+		wantErr       bool
+	}{
+		{
+			name:          "Test Bool FeatureConfig with no rules & prerequisites serves variation onBool when on",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil, nil),
+			args:          args{&target, nil},
+			want:          Evaluation{Flag: boolFlagName, Variation: onBool},
+			wantErr:       false},
+		{
+			name:          "Test Bool FeatureConfig Evaluate with no rules & prerequisites serves variation offBool when off",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOff, nil, nil),
+			args:          args{&target, nil},
+			want:          Evaluation{Flag: boolFlagName, Variation: offBool},
+			wantErr:       false},
+		{
+			name:          "Test Bool FeatureConfig Evaluate with 'prereq Foo equals true' serves offBool on match when flag on and Foo flag is off",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil, []Prerequisite{prereqFooTrue}),
+			args: args{
+				&target,
+				map[string]FeatureConfig{"Foo": makeFeatureConfig("Foo", boolKind, onBool, offBool, offBool, FeatureStateOff, nil, nil)},
+			},
+			want:    Evaluation{Flag: boolFlagName, Variation: offBool},
+			wantErr: false},
+		{
+			name:          "Test Bool FeatureConfig Evaluate with 'prereq Foo equals true' serves onBool on match when flag on and Foo flag is on",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil, []Prerequisite{prereqFooTrue}),
+			args: args{
+				&target,
+				map[string]FeatureConfig{"Foo": makeFeatureConfig("Foo", boolKind, onBool, offBool, onBool, FeatureStateOn, nil, nil)},
+			},
+			want:    Evaluation{Flag: boolFlagName, Variation: onBool},
+			wantErr: false},
+	}
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			fc := tc.featureConfig
+			got, err := fc.EvaluateWithPreReqFlags(tc.args.target, tc.args.prerequisiteFlags)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tc.wantErr)
 				return


### PR DESCRIPTION
There was a bug in the FF-Server where it wasn't evaluating flag values
properly if they had prerequisites. This is becuase the current logic
flow in FeatureConfig.Evaluate doesn't take Prerequisites into account
which meant client SDKs receiving evaluations for flags with
Prerequisites weren't receiving the correct value.

In order to evaluate prerequisites we need the flag we're
evaluating and all of the flags that may be prerequisites of it the only
way I could see to do this was to provide a way to pass in all other
flags. I didn't want to break the existing API for `Evaluate` so added a
new function that could be used for this. 

The way the `Evaluator` handles evaluating prereqs is by looking up the Prerequisite
flags from the cache but we don't have the option to do that from inside
the FeatureConfig type. So the next best thing I could think of was to
give the caller a way to pass in a map of flags that we could then do
the lookup against.

This is the corresponding change we would make in ff-server, once this PR is approved and merged I'll update the version of the ff-golang-server-sdk we use in ff-server and open up this PR https://github.com/wings-software/ff-server/pull/836