### PR TITLE
FFM-2934 Bugfix - compare custom attributes based on string values

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -3,6 +3,7 @@ package evaluation
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -83,7 +84,23 @@ func (e Evaluator) evaluateClause(clause *rest.Clause, target *Target) bool {
 		return false
 	}
 
-	object := attrValue.String()
+	object := ""
+	switch attrValue.Kind() {
+	case reflect.Int, reflect.Int64:
+		object = strconv.FormatInt(attrValue.Int(), 10)
+	case reflect.Bool:
+		object = strconv.FormatBool(attrValue.Bool())
+	case reflect.String:
+		object = attrValue.String()
+	case reflect.Array, reflect.Chan, reflect.Complex128, reflect.Complex64, reflect.Func, reflect.Interface,
+		reflect.Invalid, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer,
+		reflect.Float32, reflect.Float64, reflect.Int16, reflect.Int32, reflect.Int8, reflect.Map, reflect.Uint,
+		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
+		object = fmt.Sprintf("%v", object)
+	default:
+		// Use string formatting as last ditch effort for any unexpected values
+		object = fmt.Sprintf("%v", object)
+	}
 
 	switch operator {
 	case startsWithOperator:


### PR DESCRIPTION
It turns out [`attrValue.String()`](https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/reflect/value.go;l=2414) will not return a string value if `attrValue` is an int, boolean or any other non string type. So I've made a change to check the `Kind` of `attrValue` and then do the appropriate conversion for that kind to a string. 