### PR TITLE
Streaming connections are now closed when you call Close on a client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -199,3 +199,16 @@ var FeatureConfigsResponse = func(req *http.Request) (*http.Response, error) {
 
 	return httpmock.NewJsonResponse(200, FeatureConfigResponse)
 }
+
+func TestCfClient_Close(t *testing.T) {
+	client, err := newClient(&http.Client{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log("When I close the client for the first time I should not get an error")
+	assert.Nil(t, client.Close())
+
+	t.Log("When I close the client for the second time I should an error")
+	assert.NotNil(t, client.Close())
+}


### PR DESCRIPTION
**What**

Close wasn't closing streaming connections which meant they would stay open forever. 

**Testing**

Started up the sample sdk locally with it pointing at this version of the SDK and had it stream for a period of time before calling `Close`. Before `Close` was called I could see streamed events in the logs when I toggled a flag on/off and after `Close` was called I was not seeing streamed events in the logs whenever I toggled a flag on/off

The unit test for this is a bit light but I can't see a way to do anything more thorough without extensively refactoring the code in the client. Ideally if we could break the logic in the client out into smaller components we would be able to define some interfaces for the separate bits of logic that the client is doing e.g.

```go
type streamer interface {
   // Handle streaming connections & business logic
   Stream()
}

type authenticator interface {
   // Perform inital auth and retries
   Authenticate()
}

// Some wrapper around the analyticsService methods we use
type analyticsService interface {
}

type CfClient struct {
   stream streamer
   auth authenticator
   analytics analyticsService
}
```

Then we could have some mocks for these which would let us verify that the `Close` functionality is actually sending a close signal to each of these components. 