### PR TITLE
[FFM-3261]: Add extra information to the log

### DIFF
--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -63,6 +63,6 @@ func (t Target) GetOperator(attr string) (types.ValueType, error) {
 		reflect.Invalid, reflect.Map, reflect.Ptr, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
 		fallthrough
 	default:
-		return nil, fmt.Errorf("unexpected type: %s", value.Kind().String())
+		return nil, fmt.Errorf("unexpected type: %s for target attribute: %s", value.Kind().String(), attr)
 	}
 }


### PR DESCRIPTION
This adds more context to the log message, indicating its occured due to
a target attribute.

We saw vague logs saying "unexpected type: invalid".  It was unclear what the
unexpected type was, or what trigged the messae in the first place.