### PR TITLE
FFM-3625 - Flags with pre-reqs always evaluating to off state

### DIFF
--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -297,10 +297,8 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 	}
 
 	prereqsSatisfied := true
-	satisfiedCount := 0
 
 	for _, pre := range fc.Prerequisites {
-
 		prereqFlag, ok := flags[pre.Feature]
 		if !ok {
 			continue
@@ -309,16 +307,12 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 		variationToMatch := prereqFlag.Variations.FindByIdentifier(prereqFlag.GetVariationName(target))
 
 		if pre.Feature == prereqFlag.Feature {
-			for _, x := range pre.Variations {
-				if x == variationToMatch.Value {
-					satisfiedCount++
+			for _, variation := range pre.Variations {
+				if variation != variationToMatch.Value {
+					return false
 				}
 			}
 		}
-	}
-
-	if satisfiedCount != len(fc.Prerequisites) {
-		prereqsSatisfied = false
 	}
 
 	return prereqsSatisfied

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -297,6 +297,8 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 	}
 
 	prereqsSatisfied := true
+	satisfiedCount := 0
+
 	for _, pre := range fc.Prerequisites {
 
 		prereqFlag, ok := flags[pre.Feature]
@@ -304,12 +306,19 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 			continue
 		}
 
-		variation := fc.Variations.FindByIdentifier(fc.GetVariationName(target))
 		variationToMatch := prereqFlag.Variations.FindByIdentifier(prereqFlag.GetVariationName(target))
 
-		if variation.Value != variationToMatch.Value {
-			prereqsSatisfied = false
+		if pre.Feature == prereqFlag.Feature {
+			for _, x := range pre.Variations {
+				if x == variationToMatch.Value {
+					satisfiedCount++
+				}
+			}
 		}
+	}
+
+	if satisfiedCount != len(fc.Prerequisites) {
+		prereqsSatisfied = false
 	}
 
 	return prereqsSatisfied


### PR DESCRIPTION
**What**
A bug where MV flags with prerequisite flags are always returning an off state, I also suspect there might have been issues if there are multiple prereq flags set

[FFM-3625](https://harness.atlassian.net/browse/FFM-3625)

**Why**
This was impacting customers using the JS SDK which in turn uses the GO SDK to evaluate flags.
Currently -  the behaviour was comparing the value of a pre requisite flag against the value of a MV flag i.e. true == blue
Now - We check the prerequisites of a flag, and the status of the prereq flag to make sure they match up

**Testing**
Unit tests written for scenarios for single/multiple bools, mv flags with and without targets
Manual testing to ensure the expected behaviour occurred
