### PR TITLE
FFM-3702 Adding customer logger for evaluation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -91,7 +91,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 		return nil, err
 	}
 	client.repository = repository.New(lruCache)
-	client.evaluator, err = evaluation.NewEvaluator(client.repository, client)
+	client.evaluator, err = evaluation.NewEvaluator(client.repository, client, config.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -3,12 +3,13 @@ package evaluation
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/harness/ff-golang-server-sdk/logger"
 	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/harness/ff-golang-server-sdk/logger"
 
 	"github.com/harness/ff-golang-server-sdk/rest"
 )

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -2,6 +2,7 @@ package evaluation
 
 import (
 	"fmt"
+	"github.com/harness/ff-golang-server-sdk/logger"
 	"reflect"
 	"testing"
 
@@ -303,9 +304,11 @@ func (m TestRepository) GetFlag(identifier string) (rest.FeatureConfig, error) {
 }
 
 func TestNewEvaluator(t *testing.T) {
-	eval, _ := NewEvaluator(testRepo, nil)
+	noOpLogger := logger.NewNoOpLogger()
+	eval, _ := NewEvaluator(testRepo, nil, noOpLogger)
 	type args struct {
-		query Query
+		query  Query
+		logger logger.Logger
 	}
 	tests := []struct {
 		name    string
@@ -322,7 +325,8 @@ func TestNewEvaluator(t *testing.T) {
 		{
 			name: "should return test repo",
 			args: args{
-				query: testRepo,
+				query:  testRepo,
+				logger: noOpLogger,
 			},
 			want:    eval,
 			wantErr: false,
@@ -330,7 +334,7 @@ func TestNewEvaluator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewEvaluator(tt.args.query, nil)
+			got, err := NewEvaluator(tt.args.query, nil, noOpLogger)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewEvaluator() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -616,7 +620,8 @@ func TestEvaluator_evaluateClause(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.evaluateClause(tt.args.clause, tt.args.target); got != tt.want {
 				t.Errorf("Evaluator.evaluateClause() = %v, want %v", got, tt.want)
@@ -797,7 +802,8 @@ func TestEvaluator_evaluateRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.evaluateRules(tt.args.servingRules, tt.args.target); got != tt.want {
 				t.Errorf("Evaluator.evaluateRules() = %v, want %v", got, tt.want)
@@ -915,7 +921,8 @@ func TestEvaluator_evaluateVariationMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.evaluateVariationMap(tt.args.variationsMap, tt.args.target); got != tt.want {
 				t.Errorf("Evaluator.evaluateVariationMap() = %v, want %v", got, tt.want)
@@ -1080,7 +1087,8 @@ func TestEvaluator_evaluateFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			got, err := e.evaluateFlag(tt.args.fc, tt.args.target)
 			if (err != nil) != tt.wantErr {
@@ -1181,7 +1189,8 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.isTargetIncludedOrExcludedInSegment(tt.args.segmentList, tt.args.target); got != tt.want {
 				t.Errorf("Evaluator.isTargetIncludedOrExcludedInSegment() = %v, want %v", got, tt.want)
@@ -1263,7 +1272,8 @@ func TestEvaluator_checkPreRequisite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			got, err := e.checkPreRequisite(tt.args.parent, tt.args.target)
 			if (err != nil) != tt.wantErr {
@@ -1380,7 +1390,8 @@ func TestEvaluator_evaluate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			got, err := e.evaluate(tt.args.identifier, tt.args.target, tt.args.kind)
 			if (err != nil) != tt.wantErr {
@@ -1451,7 +1462,8 @@ func TestEvaluator_BoolVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.BoolVariation(tt.args.identifier, tt.args.target, tt.args.defaultValue); got != tt.want {
 				t.Errorf("Evaluator.BoolVariation() = %v, want %v", got, tt.want)
@@ -1517,7 +1529,8 @@ func TestEvaluator_StringVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.StringVariation(tt.args.identifier, tt.args.target, tt.args.defaultValue); got != tt.want {
 				t.Errorf("Evaluator.StringVariation() = %v, want %v", got, tt.want)
@@ -1595,7 +1608,8 @@ func TestEvaluator_IntVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.IntVariation(tt.args.identifier, tt.args.target, tt.args.defaultValue); got != tt.want {
 				t.Errorf("Evaluator.IntVariation() = %v, want %v", got, tt.want)
@@ -1673,7 +1687,8 @@ func TestEvaluator_NumberVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.NumberVariation(tt.args.identifier, tt.args.target, tt.args.defaultValue); got != tt.want {
 				t.Errorf("Evaluator.NumberVariation() = %v, want %v", got, tt.want)
@@ -1758,7 +1773,8 @@ func TestEvaluator_JSONVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := Evaluator{
-				query: tt.fields.query,
+				query:  tt.fields.query,
+				logger: logger.NewNoOpLogger(),
 			}
 			if got := e.JSONVariation(tt.args.identifier, tt.args.target, tt.args.defaultValue); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Evaluator.JSONVariation() = %v, want %v", got, tt.want)

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -2,9 +2,10 @@ package evaluation
 
 import (
 	"fmt"
-	"github.com/harness/ff-golang-server-sdk/logger"
 	"reflect"
 	"testing"
+
+	"github.com/harness/ff-golang-server-sdk/logger"
 
 	"github.com/harness/ff-golang-server-sdk/rest"
 )

--- a/logger/nooplogger.go
+++ b/logger/nooplogger.go
@@ -1,0 +1,31 @@
+package logger
+
+type NoOpLogger struct{}
+
+func NewNoOpLogger() NoOpLogger {
+	return NoOpLogger{}
+}
+
+func (m NoOpLogger) Debug(args ...interface{}) {}
+
+func (m NoOpLogger) Debugf(template string, args ...interface{}) {}
+
+func (m NoOpLogger) Info(args ...interface{}) {}
+
+func (m NoOpLogger) Infof(template string, args ...interface{}) {}
+
+func (m NoOpLogger) Warn(args ...interface{}) {}
+
+func (m NoOpLogger) Warnf(template string, args ...interface{}) {}
+
+func (m NoOpLogger) Error(args ...interface{}) {}
+
+func (m NoOpLogger) Errorf(template string, args ...interface{}) {}
+
+func (m NoOpLogger) Panic(args ...interface{}) {}
+
+func (m NoOpLogger) Panicf(template string, args ...interface{}) {}
+
+func (m NoOpLogger) Fatal(args ...interface{}) {}
+
+func (m NoOpLogger) Fatalf(template string, args ...interface{}) {}

--- a/logger/nooplogger.go
+++ b/logger/nooplogger.go
@@ -1,31 +1,46 @@
 package logger
 
+// NoOpLogger is a type that implements the Logger interface but does nothing
+// when it's methods are called
 type NoOpLogger struct{}
 
+// NewNoOpLogger returns a NoOpLogger
 func NewNoOpLogger() NoOpLogger {
 	return NoOpLogger{}
 }
 
+// Debug does nothing on a NoOpLogger
 func (m NoOpLogger) Debug(args ...interface{}) {}
 
+// Debugf does nothing on a NoOpLogger
 func (m NoOpLogger) Debugf(template string, args ...interface{}) {}
 
+// Info does nothing on a NoOpLogger
 func (m NoOpLogger) Info(args ...interface{}) {}
 
+// Infof does nothing on a NoOpLogger
 func (m NoOpLogger) Infof(template string, args ...interface{}) {}
 
+// Warn does nothing on a NoOpLogger
 func (m NoOpLogger) Warn(args ...interface{}) {}
 
+// Warnf does nothing on a NoOpLogger
 func (m NoOpLogger) Warnf(template string, args ...interface{}) {}
 
+// Error does nothing on a NoOpLogger
 func (m NoOpLogger) Error(args ...interface{}) {}
 
+// Errorf does nothing on a NoOpLogger
 func (m NoOpLogger) Errorf(template string, args ...interface{}) {}
 
+// Panic does nothing on a NoOpLogger
 func (m NoOpLogger) Panic(args ...interface{}) {}
 
+// Panicf does nothing on a NoOpLogger
 func (m NoOpLogger) Panicf(template string, args ...interface{}) {}
 
+// Fatal does nothing on a NoOpLogger
 func (m NoOpLogger) Fatal(args ...interface{}) {}
 
+// Fatalf does nothing on a NoOpLogger
 func (m NoOpLogger) Fatalf(template string, args ...interface{}) {}

--- a/tests/evaluator_test.go
+++ b/tests/evaluator_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/harness/ff-golang-server-sdk/logger"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -77,7 +78,7 @@ func TestEvaluator(t *testing.T) {
 			t.Error(err)
 		}
 		repo := repository.New(lruCache)
-		evaluator, err := evaluation.NewEvaluator(repo, nil)
+		evaluator, err := evaluation.NewEvaluator(repo, nil, logger.NewNoOpLogger())
 		if err != nil {
 			t.Error(err)
 		}

--- a/tests/evaluator_test.go
+++ b/tests/evaluator_test.go
@@ -3,11 +3,12 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/harness/ff-golang-server-sdk/logger"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/harness/ff-golang-server-sdk/logger"
 
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 


### PR DESCRIPTION
**What**
Evaluator logs where not respecting the custom logger
Also changed some info logs to debug to reduce clutter

[FFM-3702](https://harness.atlassian.net/browse/FFM-3702)

**Why**
This is because the custom logger wasn't being passed in, and therefore the default logger was always being used

**Testing**
Manually tested
Unit Tests - because I added this to the evaluator struct, I had to make a nooplogger