### PR TITLE
(MAINT) Remove noisy log

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -114,7 +114,6 @@ func (c *CfClient) start() {
 
 // PostEvaluateProcessor push the data to the analytics service
 func (c *CfClient) PostEvaluateProcessor(data *evaluation.PostEvalData) {
-	c.config.Logger.Infof("post evaluation %v", data.FeatureConfig.Feature)
 	c.analyticsService.PushToQueue(data.FeatureConfig, data.Target, data.Variation)
 }
 


### PR DESCRIPTION
**Issue**
This log printed at info level every time we evaluate a flag so can be very noisy. If we need to debug what was sent to the analytics service we can see it in the detailed analytics service debug logs [here](https://github.com/harness/ff-golang-server-sdk/blob/main/analyticsservice/analytics.go#L148) when it's pushing to ff-server.

**Fix**
Remove the log 