### PR TITLE
Change 'number' to 'int' input on number variations

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -386,8 +386,8 @@ func (e Evaluator) IntVariation(identifier string, target *Target, defaultValue 
 
 // NumberVariation returns number evaluation for target
 func (e Evaluator) NumberVariation(identifier string, target *Target, defaultValue float64) float64 {
-
-	variation, err := e.evaluate(identifier, target, "number")
+	//all numbers are stored as ints in the database
+	variation, err := e.evaluate(identifier, target, "int")
 	if err != nil {
 		e.logger.Errorf("Error while evaluating number flag '%s', err: %v", identifier, err)
 		return defaultValue

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -136,7 +136,7 @@ var (
 					Variation: &heavyWeight,
 				},
 				Variations: numberVariations,
-				Kind:       "number",
+				Kind:       "int",
 			},
 			org: {
 				Feature: org,
@@ -173,7 +173,7 @@ var (
 						Value:      invalidNumberValue,
 					},
 				},
-				Kind: "number",
+				Kind: "int",
 			},
 			invalidJSON: {
 				Feature: invalidJSON,


### PR DESCRIPTION
**What**
Change number variation to check for kind 'int' rather than 'number'
[FFM-3974](https://harness.atlassian.net/browse/FFM-3974)

**Why**
Every number variation request has the wrong type because we store them as int's and not numbers in the database

**Testing**
Manually tested
Unit tests changed where appropriate