### PR TITLE
FFM-4043 - Add checks for nested pre req flags

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -386,8 +386,8 @@ func (e Evaluator) IntVariation(identifier string, target *Target, defaultValue 
 
 // NumberVariation returns number evaluation for target
 func (e Evaluator) NumberVariation(identifier string, target *Target, defaultValue float64) float64 {
-
-	variation, err := e.evaluate(identifier, target, "number")
+	//all numbers are stored as ints in the database
+	variation, err := e.evaluate(identifier, target, "int")
 	if err != nil {
 		e.logger.Errorf("Error while evaluating number flag '%s', err: %v", identifier, err)
 		return defaultValue

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -136,7 +136,7 @@ var (
 					Variation: &heavyWeight,
 				},
 				Variations: numberVariations,
-				Kind:       "number",
+				Kind:       "int",
 			},
 			org: {
 				Feature: org,
@@ -173,7 +173,7 @@ var (
 						Value:      invalidNumberValue,
 					},
 				},
-				Kind: "number",
+				Kind: "int",
 			},
 			invalidJSON: {
 				Feature: invalidJSON,

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -306,7 +306,7 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 
 		if prereqFlag.Prerequisites != nil {
 			res := checkPreReqsForPreReqs(prereqFlag.Prerequisites, flags, target)
-			if res == false {
+			if !res {
 				return false
 			}
 		}
@@ -557,7 +557,7 @@ func checkPreReqsForPreReqs(preReqFlagPreReqs []Prerequisite, flags map[string]F
 
 		if len(nestedPreReq.Prerequisites) > 0 {
 			nested := checkPreReqsForPreReqs(nestedPreReq.Prerequisites, flags, target)
-			if nested == false {
+			if !nested {
 				return false
 			}
 		}

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -304,6 +304,13 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 			continue
 		}
 
+		if prereqFlag.Prerequisites != nil {
+			res := checkPreReqsForPreReqs(prereqFlag.Prerequisites, flags, target)
+			if res == false {
+				return false
+			}
+		}
+
 		variationToMatch := prereqFlag.Variations.FindByIdentifier(prereqFlag.GetVariationName(target))
 
 		if pre.Feature == prereqFlag.Feature {
@@ -539,4 +546,30 @@ type VariationMap struct {
 type WeightedVariation struct {
 	Variation string
 	Weight    int
+}
+
+func checkPreReqsForPreReqs(preReqFlagPreReqs []Prerequisite, flags map[string]FeatureConfig, target *Target) bool {
+	for _, preReq := range preReqFlagPreReqs {
+		nestedPreReq, ok := flags[preReq.Feature]
+		if !ok {
+			continue
+		}
+
+		if len(nestedPreReq.Prerequisites) > 0 {
+			nested := checkPreReqsForPreReqs(nestedPreReq.Prerequisites, flags, target)
+			if nested == false {
+				return false
+			}
+		}
+
+		preReqVariationToMatch := nestedPreReq.Variations.FindByIdentifier(nestedPreReq.GetVariationName(target))
+		if preReq.Feature == nestedPreReq.Feature {
+			for _, variation := range preReq.Variations {
+				if variation != preReqVariationToMatch.Value {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }

--- a/examples/getting_started.go
+++ b/examples/getting_started.go
@@ -11,14 +11,14 @@ import (
 
 var (
 	flagName string = getEnvOrDefault("FF_FLAG_NAME", "harnessappdemodarkmode")
-	apiKey   string = getEnvOrDefault("FF_API_KEY", "changeme")
+	sdkKey   string = getEnvOrDefault("FF_API_KEY", "changeme")
 )
 
 func main() {
 	log.Println("Harness SDK Getting Started")
 
 	// Create a feature flag client
-	client, err := harness.NewCfClient(apiKey)
+	client, err := harness.NewCfClient(sdkKey)
 	if err != nil {
 		log.Fatalf("could not connect to CF servers %s\n", err)
 	}
@@ -26,9 +26,9 @@ func main() {
 
 	// Create a target (different targets can get different results based on rules)
 	target := evaluation.Target{
-		Identifier: "golangsdk",
-		Name:       "GolangSDK",
-		Attributes: &map[string]interface{}{"location": "emea"},
+		Identifier: "HT_1",
+		Name:       "Harness_Target_1",
+		Attributes: &map[string]interface{}{"email": "demo@harness.io"},
 	}
 
 	// Loop forever reporting the state of the flag


### PR DESCRIPTION
**What**
Adds a recursive check to check that pre requisite flags with pre requisite flags are honoured
Slight update to example to fulfil docs changes

**Why**
Flags that had nested pre requisites were only being evaluated against the initial pre requisite

**Testing**
Unit Tests
Manual Testing


-- aware that the branching looks out of date, but need to make a tag for 0.0. and for 0.1.