### PR TITLE
FFM-4572 - Update Go version, allow custom cache, add initalLoad flag, standardise segment and flags being set

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,14 +5,14 @@ name: default
 
 steps:
 - name: check
-  image: golang:1.16.2
+  image: golang:1.18.6
   commands:
   - make check
   volumes:
   - name: gopath
     path: /go
 - name: test
-  image: golang:1.16.2
+  image: golang:1.18.6
   commands:
   - make test
   volumes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.2
+        go-version: 1.18.6
 
     - name: Check
       run: make check

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ $(GOPATH)/bin/gosec:
 
 $(GOPATH)/bin/oapi-codegen:
 	@echo "🔘 Installing oapicodegen ... (`date '+%H:%M:%S'`)"
-	@go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0
+	@go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0
 
 PHONY+= tools
 tools: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec $(GOPATH)/bin/goimports $(GOPATH)/bin/oapi-codegen

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ sec: $(GOPATH)/bin/gosec
 
 $(GOPATH)/bin/golangci-lint:
 	@echo "🔘 Installing golangci-lint... (`date '+%H:%M:%S'`)"
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.47.3
 
 $(GOPATH)/bin/golint:
 	@echo "🔘 Installing golint ... (`date '+%H:%M:%S'`)"

--- a/client/client.go
+++ b/client/client.go
@@ -86,11 +86,18 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 	if sdkKey == "" {
 		return client, types.ErrSdkCantBeEmpty
 	}
-	lruCache, err := repository.NewLruCache(10000)
-	if err != nil {
-		return nil, err
+
+	var err error
+	if client.config != nil {
+		client.repository = repository.New(config.Cache)
+	} else {
+		lruCache, err := repository.NewLruCache(10000)
+		if err != nil {
+			return nil, err
+		}
+		client.repository = repository.New(lruCache)
 	}
-	client.repository = repository.New(lruCache)
+
 	client.evaluator, err = evaluation.NewEvaluator(client.repository, client, config.Logger)
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -88,14 +88,15 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 	}
 
 	var err error
+
+	lruCache, err := repository.NewLruCache(10000)
+	if err != nil {
+		return nil, err
+	}
+	client.repository = repository.New(lruCache)
+
 	if client.config != nil {
 		client.repository = repository.New(config.Cache)
-	} else {
-		lruCache, err := repository.NewLruCache(10000)
-		if err != nil {
-			return nil, err
-		}
-		client.repository = repository.New(lruCache)
 	}
 
 	client.evaluator, err = evaluation.NewEvaluator(client.repository, client, config.Logger)

--- a/client/client.go
+++ b/client/client.go
@@ -366,7 +366,7 @@ func (c *CfClient) retrieveFlags(ctx context.Context) error {
 	}
 
 	for _, flag := range *flags.JSON200 {
-		c.repository.SetFlag(flag)
+		c.repository.SetFlag(flag, true)
 	}
 	c.config.Logger.Info("Retrieving flags finished")
 	return nil
@@ -390,7 +390,7 @@ func (c *CfClient) retrieveSegments(ctx context.Context) error {
 	}
 
 	for _, segment := range *segments.JSON200 {
-		c.repository.SetSegment(segment)
+		c.repository.SetSegment(segment, true)
 	}
 	c.config.Logger.Info("Retrieving segments finished")
 	return nil

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -53,11 +53,9 @@ func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string
 
 	// If there are any PreReqs then we need to store them as flags as well.
 	for _, x := range preReqs {
-		var state string
+		state := "off"
 		if x.Variations[0] == "true" {
 			state = "on"
-		} else {
-			state = "off"
 		}
 		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", state, nil))
 	}

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -53,7 +53,13 @@ func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string
 
 	// If there are any PreReqs then we need to store them as flags as well.
 	for _, x := range preReqs {
-		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", x.Variations[0], nil))
+		var state string
+		if x.Variations[0] == "true" {
+			state = "on"
+		} else {
+			state = "off"
+		}
+		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", state, nil))
 	}
 
 	return featureConfig

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.18.6-alpine as builder
 RUN apk update && apk add --no-cache make gcc musl-dev git ca-certificates && update-ca-certificates
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ff-golang-server-sdk
 
-go 1.16
+go 1.18
 
 require (
 	github.com/deepmap/oapi-codegen v1.11.0
@@ -16,7 +16,24 @@ require (
 	github.com/r3labs/sse v0.0.0-20201126193848-34e640891548
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.7.1
-	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	gopkg.in/cenkalti/backoff.v1 v1.1.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/net v0.0.0-20220513224357-95641704303c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -13,8 +13,8 @@ type Repository interface {
 	GetFlag(identifier string) (rest.FeatureConfig, error)
 	GetSegment(identifier string) (rest.Segment, error)
 
-	SetFlag(featureConfig rest.FeatureConfig)
-	SetSegment(segment rest.Segment)
+	SetFlag(featureConfig rest.FeatureConfig, initialLoad bool)
+	SetSegment(segment rest.Segment, initialLoad bool)
 
 	DeleteFlag(identifier string)
 	DeleteSegment(identifier string)
@@ -107,9 +107,11 @@ func (r FFRepository) GetSegment(identifier string) (rest.Segment, error) {
 }
 
 // SetFlag places a flag in the repository with the new value
-func (r FFRepository) SetFlag(featureConfig rest.FeatureConfig) {
-	if r.isFlagOutdated(featureConfig) {
-		return
+func (r FFRepository) SetFlag(featureConfig rest.FeatureConfig, initialLoad bool) {
+	if !initialLoad {
+		if r.isFlagOutdated(featureConfig) {
+			return
+		}
 	}
 	flagKey := formatFlagKey(featureConfig.Feature)
 	if r.storage != nil {
@@ -127,9 +129,11 @@ func (r FFRepository) SetFlag(featureConfig rest.FeatureConfig) {
 }
 
 // SetSegment places a segment in the repository with the new value
-func (r FFRepository) SetSegment(segment rest.Segment) {
-	if r.isSegmentOutdated(segment) {
-		return
+func (r FFRepository) SetSegment(segment rest.Segment, initialLoad bool) {
+	if !initialLoad {
+		if r.isSegmentOutdated(segment) {
+			return
+		}
 	}
 	segmentKey := formatSegmentKey(segment.Identifier)
 	if r.storage != nil {
@@ -202,9 +206,9 @@ func (r FFRepository) Close() {
 }
 
 func formatFlagKey(identifier string) string {
-	return "flags/" + identifier
+	return "flag/" + identifier
 }
 
 func formatSegmentKey(identifier string) string {
-	return "segments/" + identifier
+	return "target-segment/" + identifier
 }

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -134,7 +134,7 @@ func (c *SSEClient) handleEvent(event Event) {
 				}
 
 				if response.JSON200 != nil {
-					c.repository.SetFlag(*response.JSON200)
+					c.repository.SetFlag(*response.JSON200, false)
 				}
 			}
 
@@ -159,7 +159,7 @@ func (c *SSEClient) handleEvent(event Event) {
 					return
 				}
 				if response.JSON200 != nil {
-					c.repository.SetSegment(*response.JSON200)
+					c.repository.SetSegment(*response.JSON200, false)
 				}
 			}
 			updateWithTimeout()

--- a/test_wrapper/go.mod
+++ b/test_wrapper/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ff-golang-server-sdk/test_wrapper
 
-go 1.16
+go 1.18
 
 replace github.com/harness/ff-golang-server-sdk => ../
 

--- a/tests/evaluator_test.go
+++ b/tests/evaluator_test.go
@@ -84,10 +84,10 @@ func TestEvaluator(t *testing.T) {
 			t.Error(err)
 		}
 		for _, flag := range fixture.Flags {
-			repo.SetFlag(flag)
+			repo.SetFlag(flag, false)
 		}
 		for _, segment := range fixture.Segments {
-			repo.SetSegment(segment)
+			repo.SetSegment(segment, false)
 		}
 
 		for _, testCase := range fixture.Tests {


### PR DESCRIPTION
**What**
1. Update Go to 1.18
2. Change go get to go install for openapi codegen in makefile
3. Allow for custom cache to be honoured when set in client config
4. Add initalLoad flag to prevent outdated check on initial load of flags and segments, because new logic causes a lot of error logging on first load as you are trying to check against something that cannot exist. This is set as true on retrieveFlags, segments, then on event updates set as false. 
5. Update tests so that state is accurately set, was "true"/"false" should be "on"/"off"
6. flagKey and segmentKey is inconsistently set/get across the board
7. Pin Golangci-lint version (issue - https://github.com/golangci/golangci-lint-action/issues/535)

**Why**
Changes are necessary to keep consistency and allow for the proxy/other applications to use the client

**Testing**
Manually tested Bool, Json, String, Number flags
Manually tested PreReqs and targets
Fixed Unit tests where applicable 