### PR TITLE
[FFM-5103] changed prereq matches from value to identifer

### DIFF
--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -315,7 +315,7 @@ func prereqsSatisfied(fc FeatureConfig, target *Target, flags map[string]Feature
 
 		if pre.Feature == prereqFlag.Feature {
 			for _, variation := range pre.Variations {
-				if variation != variationToMatch.Value {
+				if variation != variationToMatch.Identifier {
 					return false
 				}
 			}

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -565,7 +565,7 @@ func checkPreReqsForPreReqs(preReqFlagPreReqs []Prerequisite, flags map[string]F
 		preReqVariationToMatch := nestedPreReq.Variations.FindByIdentifier(nestedPreReq.GetVariationName(target))
 		if preReq.Feature == nestedPreReq.Feature {
 			for _, variation := range preReq.Variations {
-				if variation != preReqVariationToMatch.Value {
+				if variation != preReqVariationToMatch.Identifier {
 					return false
 				}
 			}

--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -546,13 +546,13 @@ func TestFeatureConfig_EvaluateWithPreReqFlags(t *testing.T) {
 	onBool := Variation{
 		Name:       stringPtr("On"),
 		Value:      "true",
-		Identifier: "on",
+		Identifier: "true",
 	}
 
 	offBool := Variation{
 		Name:       stringPtr("Off"),
 		Value:      "false",
-		Identifier: "off",
+		Identifier: "false",
 	}
 
 	target := Target{


### PR DESCRIPTION
What:
Updates prerequisite checks so that they compare by flag identifier and not value
Updates feature_test.go so that the boolean flag created for a prerequisite test is inline with UI Rules - variation identifiers should be true/false only.

Why:
Was sending back wrong variation when flag identifier and value were not identical for a prerequisite flag
Was sending back wrong variation when prereq bool flag had variation identifiers that weren't true/false