### PR TITLE
[FFM-5387]: Fix Golang Group Rule Evaluate and Add Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ test:
 	go test -race -v --cover ./...
 
 report:
-	go test ./... -covermode=atomic -coverpkg=./...  -coverprofile=c.out
-	gocov convert ./c.out | gocov-html > ~/go-sdk-test-report.html
+	go test -race -v -covermode=atomic -coverprofile=cover.out ./... | tee /dev/stderr | go-junit-report -set-exit-code > junit.xml
+	gocov convert ./cover.out | gocov-html > coverage-report.html
 
 
 build-test-wrapper:

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -183,8 +183,8 @@ func (e Evaluator) evaluateRules(servingRules []rest.ServingRule, target *Target
 // of a rest.Rule.   Unlike feature clauses which are AND'd, in a case of  a group these must be OR'd.
 func (e Evaluator) evaluateGroupRules(rules []rest.Clause, target *Target) (bool, rest.Clause) {
 	for _, r := range rules {
-		rule := &r
-		if e.evaluateClause(rule, target) {
+		rule := r
+		if e.evaluateClause(&rule, target) {
 			return true, r
 		}
 	}

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -179,6 +179,17 @@ func (e Evaluator) evaluateRules(servingRules []rest.ServingRule, target *Target
 	return ""
 }
 
+// evaluateGroupRules evaluates the groups rules.  Note Group rule are represented by a rest.Clause, instead
+// of a rest.Rule.   Unlike feature clauses which are AND'd, in a case of  a group these must be OR'd.
+func (e Evaluator) evaluateGroupRules(rules []rest.Clause, target *Target) (bool, rest.Clause) {
+	for _, r := range rules {
+		if e.evaluateClause(&r, target) {
+			return true, r
+		}
+	}
+	return false, rest.Clause{}
+}
+
 func (e Evaluator) evaluateVariationMap(variationsMap []rest.VariationMap, target *Target) string {
 	if variationsMap == nil || target == nil {
 		return ""
@@ -252,11 +263,14 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 		// Should Target be included via segment rules
 		rules := segment.Rules
 		// if rules is nil pointer or points to the empty slice
-		if (rules != nil && len(*rules) > 0) && e.evaluateClauses(*rules, target) {
-			e.logger.Debugf(
-				"Target %s included in segment %s via rules", target.Name, segment.Name)
-			return true
+		if rules != nil && len(*rules) > 0 {
+			if included, clause := e.evaluateGroupRules(*rules, target); included {
+				e.logger.Debugf(
+					"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
+				return true
+			}
 		}
+
 	}
 	return false
 }

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -183,7 +183,8 @@ func (e Evaluator) evaluateRules(servingRules []rest.ServingRule, target *Target
 // of a rest.Rule.   Unlike feature clauses which are AND'd, in a case of  a group these must be OR'd.
 func (e Evaluator) evaluateGroupRules(rules []rest.Clause, target *Target) (bool, rest.Clause) {
 	for _, r := range rules {
-		if e.evaluateClause(&r, target) {
+		rule := &r
+		if e.evaluateClause(rule, target) {
 			return true, r
 		}
 	}


### PR DESCRIPTION
### What
Run evaluator tests against the ff-test-grid test-cases
Fix the group rule evaluator which was AND'ing instead of OR'ing the rules

### Why
Improve test coverage and fix an evaluator bug