### PR TITLE
 [maint]: Only run the sonarqube scan on push to main

### DIFF
--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -2,9 +2,7 @@ name: Static Code Analysis
 on:
   push:
     branches:
-      - master # or the name of your main branch
-  pull_request:
-    types: [opened, synchronize, reopened]
+      - main # or the name of your main branch
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Update the workflow to only run sonarcube on a push to main.
Because this is a public repo, secrets will not be shared from forks, so i we will just scan the main branch.