### PR TITLE
[FFM-5510]: Fixing the condition in evaluator to consider empty slice + expose Evaluate function

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -312,7 +312,7 @@ func (e Evaluator) checkPreRequisite(fc *rest.FeatureConfig, target *Target) (bo
 	return true, nil
 }
 
-// public wrapper for the evaluate.
+// Evaluate exposes evaluate to the caller.
 func (e Evaluator) Evaluate(identifier string, target *Target, kind string) (rest.Variation, error) {
 
 	return e.evaluate(identifier, target, kind)

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -251,7 +251,8 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 
 		// Should Target be included via segment rules
 		rules := segment.Rules
-		if rules != nil && e.evaluateClauses(*rules, target) {
+		// if rules is nil pointer or points to the empty slice
+		if (rules != nil && len(*rules) > 0) && e.evaluateClauses(*rules, target) {
 			e.logger.Debugf(
 				"Target %s included in segment %s via rules", target.Name, segment.Name)
 			return true
@@ -311,6 +312,12 @@ func (e Evaluator) checkPreRequisite(fc *rest.FeatureConfig, target *Target) (bo
 	return true, nil
 }
 
+// public wrapper for the evaluate.
+func (e Evaluator) Evaluate(identifier string, target *Target, kind string) (rest.Variation, error) {
+
+	return e.evaluate(identifier, target, kind)
+}
+
 func (e Evaluator) evaluate(identifier string, target *Target, kind string) (rest.Variation, error) {
 
 	if e.query == nil {
@@ -326,7 +333,7 @@ func (e Evaluator) evaluate(identifier string, target *Target, kind string) (res
 	}
 
 	if flag.Prerequisites != nil {
-		prereq, err := e.checkPreRequisite(&flag, target)
+		prereq, err := e.checkPreRequisite(&flag, target) // equivalent of evaluateWithPreReqq
 		if err != nil || !prereq {
 			return findVariation(flag.Variations, flag.OffVariation)
 		}


### PR DESCRIPTION
```
[FFM-5510]: Fixing the condition in evaluator to consider empty slice + Exposing Evaluate function
# What: 
Small fix to consider empty slice in the condition for clause evaluation
# Why:
Previously segment.rules would either be nil pointer or pointer to slice with at least one element.
Due to changes made for FFM-4150 we require extra check. 
# Testing:
Locally
```

[FFM-5510]: https://harness.atlassian.net/browse/FFM-5510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ