### PR TITLE
(FFM-6384) Match target attributes to numbers

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -3,7 +3,6 @@ package evaluation
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -98,23 +97,7 @@ func (e Evaluator) evaluateClause(clause *rest.Clause, target *Target) bool {
 		return false
 	}
 
-	object := ""
-	switch attrValue.Kind() {
-	case reflect.Int, reflect.Int64:
-		object = strconv.FormatInt(attrValue.Int(), 10)
-	case reflect.Bool:
-		object = strconv.FormatBool(attrValue.Bool())
-	case reflect.String:
-		object = attrValue.String()
-	case reflect.Array, reflect.Chan, reflect.Complex128, reflect.Complex64, reflect.Func, reflect.Interface,
-		reflect.Invalid, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer,
-		reflect.Float32, reflect.Float64, reflect.Int16, reflect.Int32, reflect.Int8, reflect.Map, reflect.Uint,
-		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
-		object = fmt.Sprintf("%v", object)
-	default:
-		// Use string formatting as last ditch effort for any unexpected values
-		object = fmt.Sprintf("%v", object)
-	}
+	object := reflectValueToString(attrValue)
 
 	switch operator {
 	case startsWithOperator:

--- a/evaluation/util.go
+++ b/evaluation/util.go
@@ -3,6 +3,7 @@ package evaluation
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/harness/ff-golang-server-sdk/log"
@@ -35,6 +36,27 @@ func getAttrValue(target *Target, attr string) reflect.Value {
 		}
 	}
 	return value
+}
+
+func reflectValueToString(val reflect.Value) string {
+	stringValue := ""
+	switch val.Kind() {
+	case reflect.Int, reflect.Int64:
+		stringValue = strconv.FormatInt(val.Int(), 10)
+	case reflect.Bool:
+		stringValue = strconv.FormatBool(val.Bool())
+	case reflect.String:
+		stringValue = val.String()
+	case reflect.Array, reflect.Chan, reflect.Complex128, reflect.Complex64, reflect.Func, reflect.Interface,
+		reflect.Invalid, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer,
+		reflect.Float32, reflect.Float64, reflect.Int16, reflect.Int32, reflect.Int8, reflect.Map, reflect.Uint,
+		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
+		stringValue = fmt.Sprintf("%v", val)
+	default:
+		// Use string formatting as last ditch effort for any unexpected values
+		stringValue = fmt.Sprintf("%v", val)
+	}
+	return stringValue
 }
 
 func findVariation(variations []rest.Variation, identifier string) (rest.Variation, error) {

--- a/evaluation/util_test.go
+++ b/evaluation/util_test.go
@@ -48,6 +48,90 @@ func Test_getAttrValueIsNil(t *testing.T) {
 	}
 }
 
+func Test_reflectValueToString(t *testing.T) {
+	type args struct {
+		attr interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "string value",
+			args: args{
+				attr: "email@harness.io",
+			},
+			want: "email@harness.io",
+		},
+		{
+			name: "int value",
+			args: args{
+				attr: 20,
+			},
+			want: "20",
+		},
+		{
+			name: "int64 value",
+			args: args{
+				attr: int64(20),
+			},
+			want: "20",
+		},
+		{
+			name: "float32 value",
+			args: args{
+				attr: float32(20),
+			},
+			want: "20",
+		},
+		{
+			name: "float32 digit value",
+			args: args{
+				attr: float32(20.5678),
+			},
+			want: "20.5678",
+		},
+		{
+			name: "float64 value",
+			args: args{
+				attr: float64(20),
+			},
+			want: "20",
+		},
+		{
+			name: "float64 digit value",
+			args: args{
+				attr: float64(20.5678),
+			},
+			want: "20.5678",
+		},
+		{
+			name: "bool true value",
+			args: args{
+				attr: true,
+			},
+			want: "true",
+		},
+		{
+			name: "bool false value",
+			args: args{
+				attr: false,
+			},
+			want: "false",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := reflect.ValueOf(tt.args.attr)
+			got := reflectValueToString(value)
+			if got != tt.want {
+				t.Errorf("valueToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_getAttrValue(t *testing.T) {
 	email := "john@doe.com"
 	type args struct {


### PR DESCRIPTION
**Issue**
Some target segment include rules weren't working for numeric values because when we went to convert these numbers to strings to compare them we always set this value to be an empty string. This meant no targets would be included in the target group correctly. 

**Fix**
Convert all numeric values to strings before the comparison stage

**Testing**
Moved this logic to a new function and added some unit tests, including for the cases that are currently failing