### PR TITLE
(FFM-6794) Add code cleanup example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ report:
 build-test-wrapper:
 	docker build -t us.gcr.io/${PROJECT_ID}/${IMAGE}:latest -f ./docker/Dockerfile .
 
+flag_cleanup_demo:
+	docker run -v ${CURDIR}:/go-sdk -e PLUGIN_DEBUG=true -e PLUGIN_PATH_TO_CODEBASE="/go-sdk/examples/code_cleanup" -e PLUGIN_PATH_TO_CONFIGURATIONS="/go-sdk/examples/code_cleanup/config" -e PLUGIN_LANGUAGE="go" -e PLUGIN_SUBSTITUTIONS="stale_flag_name=harnessappdemodarkmode,treated=true" harness/flag_cleanup:latest
+
 # Format go code and error if any changes are made
 PHONY+= format
 format:

--- a/README.md
+++ b/README.md
@@ -125,3 +125,6 @@ For more information about Feature Flags, see our [Feature Flags documentation](
 test features quicker.
 
 -------------------------
+
+### Code Cleanup (Beta)
+The go sdk supports automated code cleanup. For more info see the [docs](/examples/code_cleanup/README.md)

--- a/examples/code_cleanup/README.md
+++ b/examples/code_cleanup/README.md
@@ -1,0 +1,14 @@
+## Flag Cleanup (beta)
+The go sdk supports automated code cleanup using the Flag Cleanup drone plugin. See [here](https://github.com/harness/flag_cleanup) for detailed docs on usage of the plugin.
+
+### Run example
+1. View the [example file](/examples/code_cleanup/example.go) and observe the if block using our feature flag ```harnessappdemodarkmode```
+2. Run the flag cleanup plugin. This can be done by running the make command
+
+```make flag_cleanup_demo```
+
+or by running the docker command directly:
+
+```docker run -v ${CURDIR}:/go-sdk -e PLUGIN_DEBUG=true -e PLUGIN_PATH_TO_CODEBASE="/go-sdk/examples/code_cleanup" -e PLUGIN_PATH_TO_CONFIGURATIONS="/go-sdk/examples/code_cleanup/config" -e PLUGIN_LANGUAGE="go" -e PLUGIN_SUBSTITUTIONS="stale_flag_name=harnessappdemodarkmode,treated=true" harness/flag_cleanup:latest```
+
+3. Observe that the `if else` block has been removed from the code and the flag is now treated as globally true.

--- a/examples/code_cleanup/config/rules.toml
+++ b/examples/code_cleanup/config/rules.toml
@@ -1,0 +1,21 @@
+# Find any instance where we call the function isEnabled() with a feature flag constant
+# e.g. where @stale_flag_name is harnessappdemodarkmode this would match a call looking like isEnabled("harnessappdemodarkmode")
+# note extra params dont matter - this rule will also match isEnabled("otherparam", "harnessappdemodarkmode", morestuff)
+[[rules]]
+name = "FlagCleanup"
+query = """
+(
+    (call_expression
+        function: (identifier) @func_id
+        arguments: (argument_list
+            (interpreted_string_literal) @arg_id
+        )
+    )
+    (#eq? @func_id "isEnabled")
+    (#eq? @arg_id "\\"@stale_flag_name\\"")
+) @call_exp
+"""
+replace = "@treated"
+replace_node = "call_exp"
+groups = ["replace_expression_with_boolean_literal"]
+holes = ["stale_flag_name", "treated"]

--- a/examples/code_cleanup/example.go
+++ b/examples/code_cleanup/example.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	harness "github.com/harness/ff-golang-server-sdk/client"
+	"github.com/harness/ff-golang-server-sdk/evaluation"
+	"log"
+	"os"
+)
+
+var (
+	sdkKey string = getEnvOrDefault("FF_API_KEY", "changeme")
+	client *harness.CfClient
+)
+
+func main() {
+	log.Println("Harness SDK Getting Started")
+
+	// Create a feature flag client
+	var err error
+	client, err = harness.NewCfClient(sdkKey)
+	if err != nil {
+		log.Fatalf("could not connect to CF servers %s\n", err)
+	}
+	defer func() { client.Close() }()
+
+	if isEnabled("harnessappdemodarkmode") {
+		log.Println("Run true code path")
+	} else {
+		log.Println("Run false code path")
+	}
+}
+
+func isEnabled(flag string) bool {
+	// Create a target (different targets can get different results based on rules)
+	target := evaluation.Target{
+		Identifier: "HT_1",
+		Name:       "Harness_Target_1",
+		Attributes: &map[string]interface{}{"email": "demo@harness.io"},
+	}
+
+	resultBool, err := client.BoolVariation(flag, &target, false)
+	if err != nil {
+		log.Printf("issue evaluating flag %s, serving default value of false. err: %s", flag, err)
+	}
+	return resultBool
+
+}
+
+func getEnvOrDefault(key, defaultStr string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultStr
+	}
+	return value
+}


### PR DESCRIPTION
**Changes**
Add a flag code cleanup example for the go sdk and some docs on how to run the example. Further docs on how to craft your own custom rules for your own repo will be added to the core https://github.com/harness/flag_cleanup repo shortly. 