### PR TITLE
(FFM-7327) Use custom logger for startup and http requests

### DIFF
--- a/logger/retryablelogger.go
+++ b/logger/retryablelogger.go
@@ -1,0 +1,18 @@
+package logger
+
+// RetryableLogger implements the Logger interface required by the go-retryablehttp client and wraps our internal logger
+type RetryableLogger struct {
+	logger Logger
+}
+
+// NewRetryableLogger creates a RetryableLogger instance.
+func NewRetryableLogger(logger Logger) RetryableLogger {
+	s := RetryableLogger{}
+	s.logger = logger
+	return s
+}
+
+// Printf - logs any printf messages from the http client as debug logs
+func (s RetryableLogger) Printf(string string, args ...interface{}) {
+	s.logger.Debugf(string, args...)
+}


### PR DESCRIPTION
**Issue**
If you pass in a custom logger using the `harness.WithLogger(myLogger)` builder function there were some places it wasn't being used. 

- Default http client
- Default cache
- Default store

**Fix**
Create a wrapper that implements the go-retryablehttp libraries log interface and wrap our own sdk logger in it so all http requests use the custom logger. 
Get the logger first before we setup the default cache/store to make sure we use the passed in logger for them if it's provided.