### PR TITLE
(FFM-7347) Remove mkdir error log on startup

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -29,7 +29,7 @@ type config struct {
 
 func newDefaultConfig(log logger.Logger) *config {
 	defaultCache, _ := cache.NewLruCache(10000, log) // size of cache
-	defaultStore := storage.NewFileStore("defaultProject", storage.GetHarnessDir(), log)
+	defaultStore := storage.NewFileStore("defaultProject", storage.GetHarnessDir(log), log)
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 10

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"log"
 	"os"
 	"path"
 	"time"
@@ -42,17 +41,17 @@ type Storage interface {
 }
 
 // GetHarnessDir returns home folder for harness ff server files
-func GetHarnessDir() string {
+func GetHarnessDir(logger logger.Logger) string {
 	home, err := homedir.Dir()
 	if err != nil {
-		log.Printf("error while getting home dir: %v", err)
+		logger.Warnf("error while getting home dir: %v", err)
 		return ""
 	}
 	harnessDir := path.Join(home, "harness")
 	if _, err := os.Stat(harnessDir); os.IsNotExist(err) {
 		err := os.Mkdir(harnessDir, os.ModePerm)
 		if err != nil {
-			log.Println(err)
+			logger.Warn(err)
 		}
 	}
 	return harnessDir


### PR DESCRIPTION
**Issue**
We have 2 remaining logs that use fmt.Println/fmt.Printf instead of using the passed in logger.
These present as errors on startup when run inside our containers on ff-proxy and our own backend servers and cause confusion and clutter the logs. 

**Fix**
Log them as warnings using the actual sdk logger 