### PR TITLE
FFM-8067 Call onStreamError anytime we exit Subscribe

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -212,6 +212,16 @@ func (c *CfClient) streamConnect(ctx context.Context) {
 		c.mux.RLock()
 		defer c.mux.RUnlock()
 		c.streamConnected = false
+
+		// If an eventStreamListener has been passed to the Proxy lets notify it of the disconnected
+		// to let it know something is up with the stream it has been listening to
+		if c.config.eventStreamListener != nil {
+			c.config.eventStreamListener.Pub(context.Background(), stream.Event{
+				APIKey:      c.sdkKey,
+				Environment: c.environmentID,
+				Err:         stream.ErrStreamDisconnect,
+			})
+		}
 	}
 	conn := stream.NewSSEClient(c.sdkKey, c.token, sseClient, c.repository, c.api, c.config.Logger, streamErr,
 		c.config.eventStreamListener)

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -98,8 +98,13 @@ func (c *SSEClient) subscribe(ctx context.Context, environment string, apiKey st
 		})
 		if err != nil {
 			c.logger.Errorf("Error initializing stream: %s", err.Error())
-			c.onStreamError()
 		}
+
+		// The SSE library we use swallows the EOF error returned if a connection is closed by the server
+		// so we need to call onStreamError any time we've exited SubscribeWithContext. If we don't do
+		// this and the server closes the connection the Go SDK will still think it's connected to the stream
+		// even though it isn't
+		c.onStreamError()
 	}()
 
 	return out

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -2,9 +2,13 @@ package stream
 
 import (
 	"context"
+	"errors"
 
 	"github.com/r3labs/sse"
 )
+
+// ErrStreamDisconnect is a stream disconnect error
+var ErrStreamDisconnect error = errors.New("stream disconnect")
 
 // Connection is simple interface for streams
 type Connection interface {
@@ -28,4 +32,9 @@ type Event struct {
 	Environment string
 	// SSEEvent is the SSEEvent that was sent from the FeatureFlags server to the SDK
 	SSEEvent *sse.Event
+
+	// Err holds any errors encountered by the sdk while listening on the stream and this
+	// field should be used to pass those errors on to the EventStreamListener to let it
+	// know something has gone wrong on the stream it's listening on
+	Err error
 }


### PR DESCRIPTION
**What**

- Makes sure we call `onStreamError` anytime we break out of the SubscribeWithContext function
- If an eventListener has been passed to the Proxy we call its `Pub` method with an error. This lets the eventListener know that the stream its listening to has disconnected

**Why**

- Currently we only call `onStreamError` if SubscribeWithContext returns an error. However if the stream is intentionally closed by the server rather than [bubbling up the EOF error the SSE library we're using swallows i](https://github.com/r3labs/sse/blob/c6d5381ee3ca63828b321c16baa008fd6c0b4564/client.go#L216)t. This means we never call `onStreamError` which means the SDK thinks it's still connected to the stream and receiving SSE events which means it stops getting any changes because it isn't operating in polling mode and won't get any SSE events. Calling `onStreamError` means we'll set `streamConnected=false` and the SDK will poll for changes until it can reconnect to the stream
- For the eventListner code we can use this in the ff-proxy to pass on disconnects between the Proxy & ff-server to SDKs connected to the Proxy

**Testing**

I've been testing this out locally by getting the Proxy to close the stream with the SDK if it disconnects from ff-server