### PR TITLE
(FFM-8442) Stream disconnected change to warn

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -208,7 +208,7 @@ func (c *CfClient) streamConnect(ctx context.Context) {
 	sseClient := sse.NewClient(fmt.Sprintf("%s/stream?cluster=%s", c.config.url, c.clusterIdentifier))
 
 	streamErr := func() {
-		c.config.Logger.Error("Stream disconnected. Swapping to polling mode")
+		c.config.Logger.Warn("Stream disconnected. Swapping to polling mode")
 		c.mux.RLock()
 		defer c.mux.RUnlock()
 		c.streamConnected = false


### PR DESCRIPTION
**Changes**
Change the stream disconnected error message to warn level. In long lived applications streams disconnecting is a normal occurrence because we kick stream connections once per day. We also fallback to polling before re-establishing the stream so losing a stream connection temporarily won't cause any issues.