### PR TITLE
(FFM-8443) Stream setup log level

### DIFF
--- a/stream/sse.go
+++ b/stream/sse.go
@@ -102,7 +102,7 @@ func (c *SSEClient) subscribe(ctx context.Context, environment string, apiKey st
 
 		})
 		if err != nil {
-			c.logger.Errorf("Error initializing stream: %s", err.Error())
+			c.logger.Warnf("Error initializing stream: %s", err.Error())
 		}
 
 		// The SSE library we use swallows the EOF error returned if a connection is closed by the server


### PR DESCRIPTION
**Changes**
Transient issues can cause the stream to fail to initialise every so often. These aren't critical issues because we continue to poll for changes and retry in the background so it makes sense to move this to a warning.