### PR TITLE
[FFM-9476]: Optimize memory usage

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,10 @@
 version = 1
 
 [[analyzers]]
+name = "test-coverage"
+enabled = true
+
+[[analyzers]]
 name = "go"
 enabled = true
 

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_root = "github.com/davejohnston/ff-golang-server-sdk"

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -312,6 +312,14 @@ func (m TestRepository) GetFlags() ([]rest.FeatureConfig, error) {
 	return flags, nil
 }
 
+func (m TestRepository) GetFlagMap() (map[string]*rest.FeatureConfig, error) {
+	var flags map[string]*rest.FeatureConfig
+	for _, f := range m.flags {
+		flags[f.Feature] = &f
+	}
+	return flags, nil
+}
+
 func TestNewEvaluator(t *testing.T) {
 	noOpLogger := logger.NewNoOpLogger()
 	eval, _ := NewEvaluator(testRepo, nil, noOpLogger)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -13,6 +13,7 @@ type Repository interface {
 	GetFlag(identifier string) (rest.FeatureConfig, error)
 	GetSegment(identifier string) (rest.Segment, error)
 	GetFlags() ([]rest.FeatureConfig, error)
+	GetFlagMap() (map[string]*rest.FeatureConfig, error)
 
 	SetFlag(featureConfig rest.FeatureConfig, initialLoad bool)
 	SetFlags(initialLoad bool, envID string, featureConfig ...rest.FeatureConfig)
@@ -102,6 +103,11 @@ func (r FFRepository) GetFlag(identifier string) (rest.FeatureConfig, error) {
 // GetFlags returns all the flags /* Not implemented */
 func (r FFRepository) GetFlags() ([]rest.FeatureConfig, error) {
 	return []rest.FeatureConfig{}, nil
+}
+
+// GetFlagMap returns all flags as a mao /* Not Implemented *.
+func (r FFRepository) GetFlagMap() (map[string]*rest.FeatureConfig, error) {
+	return map[string]*rest.FeatureConfig{}, nil
 }
 
 func (r FFRepository) getSegmentAndCache(identifier string, cacheable bool) (rest.Segment, error) {


### PR DESCRIPTION
    This change supports improved memory usage of the evaluator code.
    It introduces a new function on the query interface GetFlagMap().  This returns a map of flags.  

   This is more optimal as the GetFlag function can also use a underlying map, it removes the need to maintain both a list
    and a map of flags for the caller of the evaluator.