### PR TITLE
[FFM-9476]: Optimize memory usage

### DIFF
--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -312,6 +312,14 @@ func (m TestRepository) GetFlags() ([]rest.FeatureConfig, error) {
 	return flags, nil
 }
 
+func (m TestRepository) GetFlagMap() (map[string]*rest.FeatureConfig, error) {
+	var flags map[string]*rest.FeatureConfig
+	for _, f := range m.flags {
+		flags[f.Feature] = &f
+	}
+	return flags, nil
+}
+
 func TestNewEvaluator(t *testing.T) {
 	noOpLogger := logger.NewNoOpLogger()
 	eval, _ := NewEvaluator(testRepo, nil, noOpLogger)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -15,6 +15,7 @@ type Repository interface {
 	GetFlag(identifier string) (rest.FeatureConfig, error)
 	GetSegment(identifier string) (rest.Segment, error)
 	GetFlags() ([]rest.FeatureConfig, error)
+	GetFlagMap() (map[string]*rest.FeatureConfig, error)
 
 	SetFlag(featureConfig rest.FeatureConfig, initialLoad bool)
 	SetFlags(initialLoad bool, envID string, featureConfig ...rest.FeatureConfig)
@@ -118,6 +119,11 @@ func (r FFRepository) GetFlag(identifier string) (rest.FeatureConfig, error) {
 // GetFlags returns all the flags /* Not implemented */
 func (r FFRepository) GetFlags() ([]rest.FeatureConfig, error) {
 	return []rest.FeatureConfig{}, nil
+}
+
+// GetFlagMap returns all flags as a mao /* Not Implemented *.
+func (r FFRepository) GetFlagMap() (map[string]*rest.FeatureConfig, error) {
+	return map[string]*rest.FeatureConfig{}, nil
 }
 
 func (r FFRepository) getSegmentAndCache(identifier string, cacheable bool) (rest.Segment, error) {


### PR DESCRIPTION
This change supports improved memory usage of the evaluator code. It introduces a new function on the query interface GetFlagMap().  This returns a map of flags.

This is more optimal as the GetFlag function can also use a underlying map, it removes the need to maintain both a list and a map of flags for the caller of the evaluator.