### PR TITLE
FFM-8662 Authentication errors: don't retry forever

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -105,14 +105,11 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 		return nil, err
 	}
 
-	err = client.start()
-	if err != nil {
-		return nil, err
-	}
+	client.start()
 	return client, nil
 }
 
-func (c *CfClient) start() error {
+func (c *CfClient) start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -246,7 +243,10 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 		var specificErr NonRetryableAuthError
 		if errors.As(err, &specificErr) {
 			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", specificErr.StatusCode, specificErr.Message)
+			return
 		}
+
+		// TODO handle case for retryable error
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
 		// TODO add backoff, and don't wait a minute. Also, set configurable max waitTime.
 		time.Sleep(1 * time.Minute)

--- a/client/client.go
+++ b/client/client.go
@@ -241,6 +241,18 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 			return
 		}
 
+		//var nonRetryErr NonRetryableAuthError
+		//var retryErr RetryableAuthError
+
+		//if errors.As(err, &nonRetryErr) {
+		//	c.config.Logger.Errorf("Authentication failed with a non-retryable error: '%s'", err)
+		//}
+
+		var specificErr NonRetryableAuthError
+		if errors.As(err, &specificErr) {
+			fmt.Printf("Authentication failed with a non-retryable error: %s %s", specificErr.StatusCode, specificErr.Message)
+			return err
+		}
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
 		time.Sleep(1 * time.Minute)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -266,7 +266,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 
 	responseError := findErrorInResponse(response)
 
-	// We want to retry on 500 errors only
+	// Indicate that we should retry
 	if responseError != nil && responseError.Code == "500" {
 		return RetryableAuthError{
 			StatusCode: responseError.Code,
@@ -274,7 +274,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 		}
 	}
 
-	// Don't retry on 4xx errors
+	// Indicate that we shouldn't retry on non-500 errors
 	if responseError != nil {
 		return NonRetryableAuthError{
 			StatusCode: responseError.Code,

--- a/client/client.go
+++ b/client/client.go
@@ -246,9 +246,8 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 			return
 		}
 
-		// TODO handle case for retryable error
+		// TODO add delay and backoff, don't wait a minute. Also, set configurable max retries.
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
-		// TODO add backoff, and don't wait a minute. Also, set configurable max waitTime.
 		time.Sleep(1 * time.Minute)
 	}
 }
@@ -289,7 +288,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 		}
 	}
 
-	// Defensive check to handle the case if all responses are nil
+	// Defensive check to handle the case that all responses are nil
 	if response.JSON200 == nil {
 		return RetryableAuthError{
 			StatusCode: "No errpr status code returned from server",

--- a/client/client.go
+++ b/client/client.go
@@ -240,9 +240,9 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 		if err == nil {
 		}
 
-		var specificErr NonRetryableAuthError
-		if errors.As(err, &specificErr) {
-			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", specificErr.StatusCode, specificErr.Message)
+		var nonRetryableAuthError NonRetryableAuthError
+		if errors.As(err, &nonRetryableAuthError) {
+			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", nonRetryableAuthError.StatusCode, nonRetryableAuthError.Message)
 			return
 		}
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,8 +1,21 @@
 package client
 
-import "errors"
+import "fmt"
 
-var (
-	// ErrUnauthorized displays error message for unauthorized users
-	ErrUnauthorized = errors.New("unauthorized")
-)
+type NonRetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e NonRetryableAuthError) Error() string {
+	return fmt.Sprintf("unauthorized: %s: %s", e.StatusCode, e.Message)
+}
+
+type RetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e RetryableAuthError) Error() string {
+	return fmt.Sprintf("server error: %s: %s", e.StatusCode, e.Message)
+}


### PR DESCRIPTION
# What
1. Previously, we retried on all client authentication error every minute, forever. This change means we now only retry on `500` errors. Note, the `rest.AuthenticationResponse` only has a limited number of responses:

	JSON200      *AuthenticationResponse // Continue
	JSON401      *Error // Don't retry
	JSON403      *Error // Don't retry
	JSON404      *Error // Don't retry
	JSON500      *Error // Retry

It hasn't been done in this PR yet, as it's a draft, but we will also only retry on 500 errors for a user configurable `maxRetries`
	
2. Because the client attempted to connect forever, we never returned an `error` to callers. So the the `err` returned by `NewCFClient` would never contain an error for auth issues: 

    `client, err := harness.NewCfClient(sdkKey)` // err will always be nil

*I am raising this draft PR to get feedback on what the approach should be. Should we*:

 a) bubble auth errors back up to SDK users? 
 b) or should we simply log a warning that the SDK is operating in a defaults only mode, and return the client. Note that if we go for this option, the `error` returned by client doesn't make any sense, unless we tell users that this doesn't include auth errors.


