### PR TITLE
FFM-8662 Add WaitForInitialization / Tweak Auth Retries

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -160,30 +160,19 @@ func (c *CfClient) GetClusterIdentifier() string {
 	return c.clusterIdentifier
 }
 
-//
-//// IsInitialized determines if the client is ready to be used.  This is true if it has both authenticated
-//// and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
-//func (c *CfClient) IsInitialized() (bool, error) {
-//	for i := 0; i < 30; i++ {
-//		c.initializedBoolLock.RLock()
-//		if c.initialized {
-//			c.initializedBoolLock.RUnlock()
-//			return true, nil
-//		}
-//		c.initializedBoolLock.RUnlock()
-//		time.Sleep(time.Second * 2)
-//	}
-//	return false, fmt.Errorf("timeout waiting to initialize")
-//}
-
-func (c *CfClient) IsInitialized(onError func(err error)) {
-	select {
-	case <-c.initialized:
-		return
-	case err := <-c.initializedErr:
-		onError(err)
-		close(c.initializedErr)
+// IsInitialized determines if the client is ready to be used.  This is true if it has both authenticated
+// and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
+func (c *CfClient) IsInitialized() (bool, error) {
+	for i := 0; i < 30; i++ {
+		c.initializedBoolLock.RLock()
+		if c.initialized {
+			c.initializedBoolLock.RUnlock()
+			return true, nil
+		}
+		c.initializedBoolLock.RUnlock()
+		time.Sleep(time.Second * 2)
 	}
+	return false, fmt.Errorf("timeout waiting to initialize")
 }
 
 func (c *CfClient) retrieve(ctx context.Context) bool {

--- a/client/client.go
+++ b/client/client.go
@@ -208,6 +208,11 @@ func (c *CfClient) retrieve(ctx context.Context) bool {
 	}
 
 	if ok {
+		// This flag is used by `IsInitialized` so set to true.
+		c.initializedBoolLock.Lock()
+		c.initializedBool = true
+		c.initializedBoolLock.Unlock()
+		
 		close(c.initialized)
 	}
 	return ok

--- a/client/client.go
+++ b/client/client.go
@@ -105,14 +105,11 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 		return nil, err
 	}
 
-	err = client.start()
-	if err != nil {
-		return nil, err
-	}
+	client.start()
 	return client, nil
 }
 
-func (c *CfClient) start() error {
+func (c *CfClient) start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -246,7 +243,10 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 		var specificErr NonRetryableAuthError
 		if errors.As(err, &specificErr) {
 			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", specificErr.StatusCode, specificErr.Message)
+			return
 		}
+
+		// TODO handle case for retryable error
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
 		// TODO add backoff, and don't wait a minute. Also, set configurable max waitTime.
 		time.Sleep(1 * time.Minute)

--- a/client/client.go
+++ b/client/client.go
@@ -484,6 +484,7 @@ func (c *CfClient) setAnalyticsServiceClient(ctx context.Context) {
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultValue bool) (bool, error) {
 	if c == nil {
+		c.config.Logger.Error("Error when calling BoolVariation and returning default variation: 'Client is not initialized'")
 		return defaultValue, nil
 	}
 	value := c.evaluator.BoolVariation(key, target, defaultValue)
@@ -495,6 +496,7 @@ func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultV
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaultValue string) (string, error) {
 	if c == nil {
+		c.config.Logger.Error("Error when calling StringVariation and returning default variation: 'Client is not initialized'")
 		return defaultValue, nil
 	}
 	value := c.evaluator.StringVariation(key, target, defaultValue)
@@ -506,6 +508,7 @@ func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaul
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultValue int64) (int64, error) {
 	if c == nil {
+		c.config.Logger.Error("Error when calling IntVariation and returning default variation: 'Client is not initialized'")
 		return defaultValue, nil
 	}
 	value := c.evaluator.IntVariation(key, target, int(defaultValue))
@@ -517,6 +520,7 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaultValue float64) (float64, error) {
 	if c == nil {
+		c.config.Logger.Error("Error when calling NumberVariation and returning default variation: 'Client is not initialized'")
 		return defaultValue, nil
 	}
 	value := c.evaluator.NumberVariation(key, target, defaultValue)
@@ -528,6 +532,10 @@ func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaul
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultValue types.JSON) (types.JSON, error) {
+	if c == nil {
+		c.config.Logger.Error("Error when calling JSONVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.JSONVariation(key, target, defaultValue)
 	return value, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -241,6 +241,18 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 			return
 		}
 
+		//var nonRetryErr NonRetryableAuthError
+		//var retryErr RetryableAuthError
+
+		//if errors.As(err, &nonRetryErr) {
+		//	c.config.Logger.Errorf("Authentication failed with a non-retryable error: '%s'", err)
+		//}
+
+		var specificErr NonRetryableAuthError
+		if errors.As(err, &specificErr) {
+			fmt.Printf("Authentication failed with a non-retryable error: %s %s", specificErr.StatusCode, specificErr.Message)
+			return err
+		}
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
 		time.Sleep(1 * time.Minute)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -165,7 +165,7 @@ func (c *CfClient) GetClusterIdentifier() string {
 func (c *CfClient) IsInitialized() (bool, error) {
 	for i := 0; i < 30; i++ {
 		c.initializedBoolLock.RLock()
-		if c.initialized {
+		if c.initializedBool {
 			c.initializedBoolLock.RUnlock()
 			return true, nil
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -124,7 +124,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 			// We return the client but leave it in un-initialized state by not setting the relevant initialized flag.
 			// This ensures any subsequent calls to the client don't potentially result in a panic. For example, if a user
 			// calls BoolVariation we can log that the client is not initialized and return the user the default variation.
-			return client, fmt.Errorf("error during initialization: %v", initErr)
+			return client, initErr
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -266,7 +266,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 
 	responseError := findErrorInResponse(response)
 
-	// We want to retry on 500 errors only
+	// Indicate that we should retry
 	if responseError != nil && responseError.Code == "500" {
 		return RetryableAuthError{
 			StatusCode: responseError.Code,
@@ -274,7 +274,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 		}
 	}
 
-	// Don't retry on 4xx errors
+	// Indicate that we shouldn't retry on non-500 errors
 	if responseError != nil {
 		return NonRetryableAuthError{
 			StatusCode: responseError.Code,

--- a/client/client.go
+++ b/client/client.go
@@ -284,7 +284,8 @@ func (c *CfClient) initAuthentication(ctx context.Context) error {
 			return err
 		}
 
-		if retries >= c.config.maxAuthRetries {
+		// -1 is the default maxAuthRetries option and indicates there should be no max retries
+		if c.config.maxAuthRetries != -1 && retries >= c.config.maxAuthRetries {
 			c.config.Logger.Errorf("Authentication failed with error: '%s'. Exceeded max retries '%s'.", err, c.config.maxAuthRetries)
 			return err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -212,7 +212,7 @@ func (c *CfClient) retrieve(ctx context.Context) bool {
 		c.initializedBoolLock.Lock()
 		c.initializedBool = true
 		c.initializedBoolLock.Unlock()
-		
+
 		close(c.initialized)
 	}
 	return ok
@@ -483,6 +483,9 @@ func (c *CfClient) setAnalyticsServiceClient(ctx context.Context) {
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultValue bool) (bool, error) {
+	if c == nil {
+		return defaultValue, nil
+	}
 	value := c.evaluator.BoolVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -491,6 +494,9 @@ func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultV
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaultValue string) (string, error) {
+	if c == nil {
+		return defaultValue, nil
+	}
 	value := c.evaluator.StringVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -499,6 +505,9 @@ func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaul
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultValue int64) (int64, error) {
+	if c == nil {
+		return defaultValue, nil
+	}
 	value := c.evaluator.IntVariation(key, target, int(defaultValue))
 	return int64(value), nil
 }
@@ -507,6 +516,9 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaultValue float64) (float64, error) {
+	if c == nil {
+		return defaultValue, nil
+	}
 	value := c.evaluator.NumberVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -524,7 +536,7 @@ func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultV
 // should no longer be used
 func (c *CfClient) Close() error {
 	if c == nil {
-		return errors.New("client is not initialized")
+		return errors.New("attempted to close client that is not initialized")
 	}
 	if c.stopped.get() {
 		return errors.New("client already closed")

--- a/client/client.go
+++ b/client/client.go
@@ -272,7 +272,7 @@ func (c *CfClient) initAuthentication(ctx context.Context) error {
 
 		var nonRetryableAuthError NonRetryableAuthError
 		if errors.As(err, &nonRetryableAuthError) {
-			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", nonRetryableAuthError.StatusCode, nonRetryableAuthError.Message)
+			c.config.Logger.Error("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", nonRetryableAuthError.StatusCode, nonRetryableAuthError.Message)
 			return err
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -246,9 +246,8 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 			return
 		}
 
-		// TODO handle case for retryable error
+		// TODO add delay and backoff, don't wait a minute. Also, set configurable max retries.
 		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in 1 minute.", err)
-		// TODO add backoff, and don't wait a minute. Also, set configurable max waitTime.
 		time.Sleep(1 * time.Minute)
 	}
 }
@@ -289,7 +288,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 		}
 	}
 
-	// Defensive check to handle the case if all responses are nil
+	// Defensive check to handle the case that all responses are nil
 	if response.JSON200 == nil {
 		return RetryableAuthError{
 			StatusCode: "No errpr status code returned from server",

--- a/client/client.go
+++ b/client/client.go
@@ -240,9 +240,9 @@ func (c *CfClient) initAuthentication(ctx context.Context) {
 		if err == nil {
 		}
 
-		var specificErr NonRetryableAuthError
-		if errors.As(err, &specificErr) {
-			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", specificErr.StatusCode, specificErr.Message)
+		var nonRetryableAuthError NonRetryableAuthError
+		if errors.As(err, &nonRetryableAuthError) {
+			fmt.Printf("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", nonRetryableAuthError.StatusCode, nonRetryableAuthError.Message)
 			return
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -89,7 +89,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 	}
 
 	if sdkKey == "" {
-		return nil, types.ErrSdkCantBeEmpty
+		return client, types.ErrSdkCantBeEmpty
 	}
 
 	var err error

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -47,7 +47,6 @@ func TestNewCfClient(t *testing.T) {
 		name          string
 		sdkKey        string
 		mockResponder func()
-		wantClient    bool
 		wantErr       error
 	}{
 		{
@@ -56,14 +55,12 @@ func TestNewCfClient(t *testing.T) {
 			mockResponder: func() {
 				// setup happy path mock responder
 			},
-			wantClient: true,
-			wantErr:    nil,
+			wantErr: nil,
 		},
 		{
 			name:          "Empty SDK key",
 			sdkKey:        "",
 			mockResponder: nil,
-			wantClient:    false,
 			wantErr:       types.ErrSdkCantBeEmpty,
 		},
 		{
@@ -74,13 +71,11 @@ func TestNewCfClient(t *testing.T) {
 				registerResponders(authErrorResponder, TargetSegmentsResponse, FeatureConfigsResponse)
 
 			},
-			wantClient: false,
 			wantErr: client.NonRetryableAuthError{
 				StatusCode: "401",
 				Message:    "aa",
 			},
 		},
-		// Add more scenarios as needed
 	}
 
 	for _, tt := range tests {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -174,7 +174,6 @@ func TestCfClient_NewClient(t *testing.T) {
 				secondAuthResponse := AuthResponse(200, ValidAuthToken)
 
 				registerStatefulResponders([]httpmock.Responder{firstAuthResponse, secondAuthResponse}, TargetSegmentsResponse, FeatureConfigsResponse)
-				//registerResponders(authSuccessResponse, TargetSegmentsResponse, FeatureConfigsResponse)
 
 			},
 			wantErr: nil,
@@ -294,14 +293,18 @@ func newAsyncClient(httpClient *http.Client) (*client.CfClient, error) {
 	)
 }
 
-func newSynchronousClient(httpClient *http.Client, sdkKey string) (*client.CfClient, error) {
-	return client.NewCfClient(sdkKey,
+func newSynchronousClient(httpClient *http.Client, sdkKey string, extraOptions ...client.ConfigOption) (*client.CfClient, error) {
+	// Base options
+	baseOptions := []client.ConfigOption{
 		client.WithURL(URL),
 		client.WithStreamEnabled(false),
 		client.WithHTTPClient(httpClient),
 		client.WithStoreEnabled(false),
 		client.WithWaitForInitialized(true),
-	)
+	}
+	// Combine base options with extra options
+	allOptions := append(baseOptions, extraOptions...)
+	return client.NewCfClient(sdkKey, allOptions...)
 }
 
 // target creates a new Target with some default values

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -41,7 +41,7 @@ func registerResponders(authResponder httpmock.Responder, targetSegmentsResponde
 	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/feature-configs", featureConfigsResponder)
 }
 
-func TestNewCfClient(t *testing.T) {
+func TestCfClient_NewClient(t *testing.T) {
 
 	tests := []struct {
 		name          string
@@ -49,15 +49,15 @@ func TestNewCfClient(t *testing.T) {
 		mockResponder func()
 		wantErr       error
 	}{
-		//{
-		//	name:   "Successful client creation",
-		//	sdkKey: sdkKey,
-		//	mockResponder: func() {
-		//		registerResponders(ValidAuthResponse, TargetSegmentsResponse, FeatureConfigsResponse)
-		//
-		//	},
-		//	wantErr: nil,
-		//},
+		{
+			name:   "Successful client creation",
+			sdkKey: sdkKey,
+			mockResponder: func() {
+				registerResponders(ValidAuthResponse, TargetSegmentsResponse, FeatureConfigsResponse)
+
+			},
+			wantErr: nil,
+		},
 		{
 			name:          "Empty SDK key",
 			sdkKey:        "",
@@ -73,8 +73,8 @@ func TestNewCfClient(t *testing.T) {
 
 			},
 			wantErr: client.NonRetryableAuthError{
-				StatusCode: "401",
-				Message:    "aa",
+				StatusCode: "",
+				Message:    "",
 			},
 		},
 	}
@@ -89,8 +89,6 @@ func TestNewCfClient(t *testing.T) {
 			_, err := newClientWaitForInit(http.DefaultClient, tt.sdkKey)
 
 			assert.Equal(t, tt.wantErr, err)
-
-			httpmock.Reset()
 
 		})
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,8 +2,10 @@ package client_test
 
 import (
 	"encoding/json"
+	"github.com/harness/ff-golang-server-sdk/types"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/harness/ff-golang-server-sdk/client"
@@ -15,10 +17,13 @@ import (
 )
 
 const (
-	sdkKey = "27bed8d2-2610-462b-90eb-d80fd594b623"
-	URL    = "http://localhost/api/1.0"
+	sdkKey               = "27bed8d2-2610-462b-90eb-d80fd594b623"
+	URL                  = "http://localhost/api/1.0"
+	URLWhichReturnsError = "http://localhost/api/1.0/error"
+
 	//nolint
-	AuthToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiMTA0MjM5NzYtODQ1MS00NmZjLTg2NzctYmNiZDM3MTA3M2JhIiwiZW52aXJvbm1lbnQiOiI3ZWQxMDI1ZC1hOWIxLTQxMjktYTg4Zi1lMjdlZjM2MDk4MmQiLCJwcm9qZWN0SWRlbnRpZmllciI6IiIsImVudmlyb25tZW50SWRlbnRpZmllciI6IlByZVByb2R1Y3Rpb24iLCJhY2NvdW50SUQiOiIiLCJvcmdhbml6YXRpb24iOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJjbHVzdGVySWRlbnRpZmllciI6IjEifQ.E4O_u42HkR0q4AwTTViFTCnNa89Kwftks7Gh-GvQfuE"
+	AuthToken      = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiMTA0MjM5NzYtODQ1MS00NmZjLTg2NzctYmNiZDM3MTA3M2JhIiwiZW52aXJvbm1lbnQiOiI3ZWQxMDI1ZC1hOWIxLTQxMjktYTg4Zi1lMjdlZjM2MDk4MmQiLCJwcm9qZWN0SWRlbnRpZmllciI6IiIsImVudmlyb25tZW50SWRlbnRpZmllciI6IlByZVByb2R1Y3Rpb24iLCJhY2NvdW50SUQiOiIiLCJvcmdhbml6YXRpb24iOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJjbHVzdGVySWRlbnRpZmllciI6IjEifQ.E4O_u42HkR0q4AwTTViFTCnNa89Kwftks7Gh-GvQfuE"
+	EmptyAuthToken = ""
 )
 
 // TestMain runs before the other tests
@@ -27,16 +32,76 @@ func TestMain(m *testing.M) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	// Register Default Responders
-	httpmock.RegisterResponder("POST", "http://localhost/api/1.0/client/auth", ValidAuthResponse)
-	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/target-segments", TargetSegmentsResponse)
-	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/feature-configs", FeatureConfigsResponse)
-
 	os.Exit(m.Run())
 }
 
-func TestCfClient_BoolVariation(t *testing.T) {
+func registerResponders(authResponder httpmock.Responder, targetSegmentsResponder httpmock.Responder, featureConfigsResponder httpmock.Responder) {
+	httpmock.RegisterResponder("POST", "http://localhost/api/1.0/client/auth", authResponder)
+	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/target-segments", targetSegmentsResponder)
+	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/feature-configs", featureConfigsResponder)
+}
 
+func TestNewCfClient(t *testing.T) {
+	tests := []struct {
+		name          string
+		sdkKey        string
+		mockResponder func()
+		wantClient    bool
+		wantErr       error
+	}{
+		{
+			name:   "Successful client creation",
+			sdkKey: sdkKey,
+			mockResponder: func() {
+				// setup happy path mock responder
+			},
+			wantClient: true,
+			wantErr:    nil,
+		},
+		{
+			name:          "Empty SDK key",
+			sdkKey:        "",
+			mockResponder: nil,
+			wantClient:    false,
+			wantErr:       types.ErrSdkCantBeEmpty,
+		},
+		{
+			name:   "Authentication failed with non-retryable error",
+			sdkKey: sdkKey,
+			mockResponder: func() {
+				//authErrorResponder := ErrorResponse(401, "Unauthorized request")
+				registerResponders(ValidAuthResponse, TargetSegmentsResponse, FeatureConfigsResponse)
+			},
+			wantClient: false,
+			wantErr: client.NonRetryableAuthError{
+				StatusCode: "401",
+				Message:    "aa",
+			},
+		},
+		// Add more scenarios as needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockResponder != nil {
+				tt.mockResponder()
+			}
+
+			client, err := newClient(http.DefaultClient)
+
+			if tt.wantClient {
+				assert.NotNil(t, client)
+			} else {
+				assert.Nil(t, client)
+			}
+
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
+func TestCfClient_BoolVariation(t *testing.T) {
+	registerResponders(ValidAuthResponse, TargetSegmentsResponse, FeatureConfigsResponse)
 	client, target, err := MakeNewClientAndTarget()
 	if err != nil {
 		t.Error(err)
@@ -75,6 +140,7 @@ func TestCfClient_BoolVariation(t *testing.T) {
 }
 
 func TestCfClient_StringVariation(t *testing.T) {
+	registerResponders(ValidAuthResponse, TargetSegmentsResponse, FeatureConfigsResponse)
 
 	client, target, err := MakeNewClientAndTarget()
 	if err != nil {
@@ -149,8 +215,73 @@ func target() *evaluation.Target {
 }
 
 var ValidAuthResponse = func(req *http.Request) (*http.Response, error) {
-	return httpmock.NewJsonResponse(200, rest.AuthenticationResponse{
-		AuthToken: AuthToken})
+	return httpmock.NewJsonResponse(403, http.Response{Status: "403"})
+}
+
+var RetryableErrorAuthResponse = func(req *http.Request) (*http.Response, error) {
+	return httpmock.NewJsonResponse(500, rest.AuthenticationResponse{
+		AuthToken: EmptyAuthToken})
+}
+
+var NonRetryableErrorAuthResponse = func(req *http.Request) (*http.Response, error) {
+	return httpmock.NewJsonResponse(200, rest.AuthenticateResponse{
+		Body:         nil,
+		HTTPResponse: nil,
+		JSON200:      nil,
+		JSON401: &rest.Error{
+			Code:    "401",
+			Message: "401 error from ff-server",
+		},
+		JSON403: nil,
+		JSON404: nil,
+		JSON500: nil,
+	})
+}
+
+var ErrorResponse = func(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
+	switch statusCode {
+	case 401:
+		return func(req *http.Request) (*http.Response, error) {
+			// Return the appropriate error based on the provided status code
+			return httpmock.NewJsonResponse(statusCode, rest.AuthenticateResponse{
+				JSON401: &rest.Error{
+					Code:    strconv.Itoa(statusCode),
+					Message: message,
+				},
+			})
+		}
+	case 403:
+		return func(req *http.Request) (*http.Response, error) {
+			// Return the appropriate error based on the provided status code
+			return httpmock.NewJsonResponse(statusCode, rest.AuthenticateResponse{
+				JSON403: &rest.Error{
+					Code:    strconv.Itoa(statusCode),
+					Message: message,
+				},
+			})
+		}
+	case 404:
+		return func(req *http.Request) (*http.Response, error) {
+			// Return the appropriate error based on the provided status code
+			return httpmock.NewJsonResponse(statusCode, rest.AuthenticateResponse{
+				JSON404: &rest.Error{
+					Code:    strconv.Itoa(statusCode),
+					Message: message,
+				},
+			})
+		}
+	case 500:
+		return func(req *http.Request) (*http.Response, error) {
+			// Return the appropriate error based on the provided status code
+			return httpmock.NewJsonResponse(statusCode, rest.AuthenticateResponse{
+				JSON500: &rest.Error{
+					Code:    strconv.Itoa(statusCode),
+					Message: message,
+				},
+			})
+		}
+	}
+	panic("Unsupported status code for test")
 }
 
 var TargetSegmentsResponse = func(req *http.Request) (*http.Response, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -283,7 +283,7 @@ func MakeNewSynchronousClientAndTarget(sdkKey string) (*client.CfClient, *evalua
 	return client, target, nil
 }
 
-// newAsyncClient creates a new client with some default options
+// newAsyncClient creates a new client which does not wait for initailzation to complete, and includes default options
 func newAsyncClient(httpClient *http.Client) (*client.CfClient, error) {
 	return client.NewCfClient(ValidSDKKey,
 		client.WithURL(URL),
@@ -293,8 +293,8 @@ func newAsyncClient(httpClient *http.Client) (*client.CfClient, error) {
 	)
 }
 
+// newSynchronousClient creates a new client which waits for initialization to complete, and includes default options/extra options if required.
 func newSynchronousClient(httpClient *http.Client, sdkKey string, extraOptions ...client.ConfigOption) (*client.CfClient, error) {
-	// Base options
 	baseOptions := []client.ConfigOption{
 		client.WithURL(URL),
 		client.WithStreamEnabled(false),
@@ -302,7 +302,7 @@ func newSynchronousClient(httpClient *http.Client, sdkKey string, extraOptions .
 		client.WithStoreEnabled(false),
 		client.WithWaitForInitialized(true),
 	}
-	// Combine base options with extra options
+
 	allOptions := append(baseOptions, extraOptions...)
 	return client.NewCfClient(sdkKey, allOptions...)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -161,7 +161,7 @@ func TestCfClient_NewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "Authentication failed with 500 and retries twice",
+			name: "Authentication failed with 500 and retries once",
 			newClientFunc: func() (*client.CfClient, error) {
 				return newSynchronousClient(http.DefaultClient, ValidSDKKey)
 			},
@@ -170,8 +170,11 @@ func TestCfClient_NewClient(t *testing.T) {
 				"message": "internal server error",
 				"code": "500"
 				}`
-				authSuccessResponse := AuthResponseDetailed(500, "500 server error", bodyString)
-				registerResponders(authSuccessResponse, TargetSegmentsResponse, FeatureConfigsResponse)
+				firstAuthResponse := AuthResponseDetailed(500, "success", bodyString)
+				secondAuthResponse := AuthResponse(200, ValidAuthToken)
+
+				registerStatefulResponders([]httpmock.Responder{firstAuthResponse, secondAuthResponse}, TargetSegmentsResponse, FeatureConfigsResponse)
+				//registerResponders(authSuccessResponse, TargetSegmentsResponse, FeatureConfigsResponse)
 
 			},
 			wantErr: nil,

--- a/client/config.go
+++ b/client/config.go
@@ -28,6 +28,7 @@ type config struct {
 	enableAnalytics     bool
 	proxyMode           bool
 	waitForInitialized  bool
+	maxAuthRetries      int
 }
 
 func newDefaultConfig(log logger.Logger) *config {
@@ -53,5 +54,7 @@ func newDefaultConfig(log logger.Logger) *config {
 		enableStore:     true,
 		enableAnalytics: true,
 		proxyMode:       false,
+		// Indicate that we should retry forever by default
+		maxAuthRetries: -1,
 	}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -27,6 +27,7 @@ type config struct {
 	eventStreamListener stream.EventStreamListener
 	enableAnalytics     bool
 	proxyMode           bool
+	waitForInitialized  bool
 }
 
 func newDefaultConfig(log logger.Logger) *config {

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,8 +1,21 @@
 package client
 
-import "errors"
+import "fmt"
 
-var (
-	// ErrUnauthorized displays error message for unauthorized users
-	ErrUnauthorized = errors.New("unauthorized")
-)
+type NonRetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e NonRetryableAuthError) Error() string {
+	return fmt.Sprintf("unauthorized: %s: %s", e.StatusCode, e.Message)
+}
+
+type RetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e RetryableAuthError) Error() string {
+	return fmt.Sprintf("server error: %s: %s", e.StatusCode, e.Message)
+}

--- a/client/options.go
+++ b/client/options.go
@@ -111,3 +111,9 @@ func WithProxyMode(b bool) ConfigOption {
 		config.proxyMode = b
 	}
 }
+
+func WithWaitForInitialized(b bool) ConfigOption {
+	return func(config *config) {
+		config.waitForInitialized = b
+	}
+}

--- a/client/options.go
+++ b/client/options.go
@@ -117,3 +117,9 @@ func WithWaitForInitialized(b bool) ConfigOption {
 		config.waitForInitialized = b
 	}
 }
+
+func WithMaxAuthRetries(i int) ConfigOption {
+	return func(config *config) {
+		config.maxAuthRetries = i
+	}
+}


### PR DESCRIPTION
DRAFT - just after feedback on the approach for synchronous client init

- Adds optional synchronous startup option `WaitForInitialization` by:

    - Using a channel to block until initialised 
    - Using a separate error channel to handle errors during initilization - NOTE: only one of three start up methods that does error handling is `authenticate` , so currently that's the only one of the start up methods that write to the new error channel. 
    - If an init error occurs either in async or sync node, we now return the error back to the caller. If users attempt to call `XVariation` in this case the SDK will log an error and return the default variation.
    - TODO configurable wait time for init block before stopping and returning an error. Same as above the SDK will log a warning and return the default variation after this happens.
    
    
- Updates retry logic 
    - Only retry on 500 errors
    - TODO: don't retry forever

Tests
TODO: New client tests 
Manual so far