### PR TITLE
FFM-8662 Add WaitForInitialized / Improve Authentication Retries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this scenario, the client will initialize in the background, making it possib
 Be mindful that if you attempt to evaluate a feature flag before the client has fully initialized, it will return the default value provided in the evaluation call.
 
 ### Blocking Initialization
-In some cases, you may want your application to wait for the client to finish initializing before continuing the startup process. To achieve this, you can use the WaitForInitialized method, which will block until the client is fully initialized or until the provided timeout is reached. Example usage:
+In some cases, you may want your application to wait for the client to finish initializing before continuing. To achieve this, you can use the `WithWaitForInitialized` option, which will block until the client is fully initialized or until the provided timeout is reached. Example usage:
 
 ```go
 client, err := harness.NewCfClient(sdkKey, harness.WithWaitForInitialized(true))

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this scenario, the client will initialize in the background, making it possib
 Be mindful that if you attempt to evaluate a feature flag before the client has fully initialized, it will return the default value provided in the evaluation call.
 
 ### Blocking Initialization
-In some cases, you may want your application to wait for the client to finish initializing before continuing. To achieve this, you can use the `WithWaitForInitialized` option, which will block until the client is fully initialized or until the provided timeout is reached. Example usage:
+In some cases, you may want your application to wait for the client to finish initializing before continuing. To achieve this, you can use the `WithWaitForInitialized` option, which will block until the client is fully initialized. Example usage:
 
 ```go
 client, err := harness.NewCfClient(sdkKey, harness.WithWaitForInitialized(true))

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client, err := harness.NewCfClient(apiKey)
 In this scenario, the client will initialize in the background, making it possible to use the client even if it hasn’t finished initializing. 
 Be mindful that if you attempt to evaluate a feature flag before the client has fully initialized, it will return the default value provided in the evaluation call.
 
-#### Blocking Initialization
+### Blocking Initialization
 In some cases, you may want your application to wait for the client to finish initializing before continuing the startup process. To achieve this, you can use the WaitForInitialized method, which will block until the client is fully initialized or until the provided timeout is reached. Example usage:
 
 ```go
@@ -57,7 +57,9 @@ log.ErrorF("could not connect to FF servers %s", err)
 ```
 
 
-In this example, WaitForInitialized will block for up to 5 authentication attempts. If the client is not initialized within 5 authentication attempts, it will return an error. If you evaluate a feature flag in this state
+In this example, WaitForInitialized will block for up to 5 authentication attempts. If the client is not initialized within 5 authentication attempts, it will return an error.
+
+This can be useful if you need to unblock after a certain timeIf you evaluate a feature flag in this state
 the default variation will be returned.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ log.ErrorF("could not connect to FF servers %s", err)
 
 In this example, WaitForInitialized will block for up to 5 authentication attempts. If the client is not initialized within 5 authentication attempts, it will return an error.
 
-This can be useful if you need to unblock after a certain timeIf you evaluate a feature flag in this state
+This can be useful if you need to unblock after a certain time. **NOTE**: you evaluate a feature flag in this state
 the default variation will be returned.
 
 ```go
 // Try to authenticate only 5 times before returning a result
 client, err := harness.NewCfClient(sdkKey, harness.WithWaitForInitialized(true), harness.WithMaxAuthRetries(5))
+
 if err != nil {
 log.Fatalf("client did not initialize in time: %s", err)
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ log.ErrorF("could not connect to FF servers %s", err)
 
 In this example, WaitForInitialized will block for up to 5 authentication attempts. If the client is not initialized within 5 authentication attempts, it will return an error.
 
-This can be useful if you need to unblock after a certain time. **NOTE**: you evaluate a feature flag in this state
+This can be useful if you need to unblock after a certain time. **NOTE**: if you evaluate a feature flag in this state
 the default variation will be returned.
 
 ```go

--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -24,7 +24,7 @@ const (
 	variationValueAttribute      string = "featureValue"
 	targetAttribute              string = "target"
 	sdkVersionAttribute          string = "SDK_VERSION"
-	sdkVersion                   string = "1.0.0"
+	sdkVersion                   string = "1.19.0"
 	sdkTypeAttribute             string = "SDK_TYPE"
 	sdkType                      string = "server"
 	sdkLanguageAttribute         string = "SDK_LANGUAGE"

--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -24,7 +24,7 @@ const (
 	variationValueAttribute      string = "featureValue"
 	targetAttribute              string = "target"
 	sdkVersionAttribute          string = "SDK_VERSION"
-	sdkVersion                   string = "1.19.0"
+	sdkVersion                   string = "1.12.0"
 	sdkTypeAttribute             string = "SDK_TYPE"
 	sdkType                      string = "server"
 	sdkLanguageAttribute         string = "SDK_LANGUAGE"

--- a/client/client.go
+++ b/client/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"strings"
 	"sync"
@@ -53,8 +54,10 @@ type CfClient struct {
 	streamConnectedLock sync.RWMutex
 	authenticated       chan struct{}
 	postEvalChan        chan evaluation.PostEvalData
-	initialized         bool
-	initializedLock     sync.RWMutex
+	initializedBool     bool
+	initializedBoolLock sync.RWMutex
+	initialized         chan struct{}
+	initializedErr      chan error
 	analyticsService    *analyticsservice.AnalyticsService
 	clusterIdentifier   string
 	stop                chan struct{}
@@ -82,6 +85,8 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 		postEvalChan:      make(chan evaluation.PostEvalData),
 		stop:              make(chan struct{}),
 		stopped:           newAtomicBool(false),
+		initialized:       make(chan struct{}),
+		initializedErr:    make(chan error),
 	}
 
 	if sdkKey == "" {
@@ -106,6 +111,24 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 	}
 
 	client.start()
+	if config.waitForInitialized {
+		var initErr error
+
+		select {
+		case <-client.initialized:
+			return client, nil
+		case err := <-client.initializedErr:
+			initErr = err
+		}
+
+		if initErr != nil {
+			// We return the client but leave it in un-initialized state by not setting the relevant initialized flag.
+			// This ensures any subsequent calls to the client don't potentially result in a panic. For example, if a user
+			// calls BoolVariation we can log that the client is not initialized and return the user the default variation.
+			return client, initErr
+		}
+	}
+
 	return client, nil
 }
 
@@ -117,7 +140,11 @@ func (c *CfClient) start() {
 		cancel()
 	}()
 
-	go c.initAuthentication(ctx)
+	go func() {
+		if err := c.initAuthentication(context.Background()); err != nil {
+			c.initializedErr <- err
+		}
+	}()
 	go c.setAnalyticsServiceClient(ctx)
 	go c.pullCronJob(ctx)
 }
@@ -141,12 +168,12 @@ func (c *CfClient) GetClusterIdentifier() string {
 // and successfully retrieved flags.  If it takes longer than 1 minute the call will timeout and return an error.
 func (c *CfClient) IsInitialized() (bool, error) {
 	for i := 0; i < 30; i++ {
-		c.initializedLock.RLock()
-		if c.initialized {
-			c.initializedLock.RUnlock()
+		c.initializedBoolLock.RLock()
+		if c.initializedBool {
+			c.initializedBoolLock.RUnlock()
 			return true, nil
 		}
-		c.initializedLock.RUnlock()
+		c.initializedBoolLock.RUnlock()
 		time.Sleep(time.Second * 2)
 	}
 	return false, fmt.Errorf("timeout waiting to initialize")
@@ -185,9 +212,12 @@ func (c *CfClient) retrieve(ctx context.Context) bool {
 	}
 
 	if ok {
-		c.initializedLock.Lock()
-		c.initialized = true
-		c.initializedLock.Unlock()
+		// This flag is used by `IsInitialized` so set to true.
+		c.initializedBoolLock.Lock()
+		c.initializedBool = true
+		c.initializedBoolLock.Unlock()
+
+		close(c.initialized)
 	}
 	return ok
 }
@@ -233,15 +263,44 @@ func (c *CfClient) streamConnect(ctx context.Context) {
 	c.streamConnected = true
 }
 
-func (c *CfClient) initAuthentication(ctx context.Context) {
-	// attempt to authenticate every minute until we succeed
+func (c *CfClient) initAuthentication(ctx context.Context) error {
+	baseDelay := 1 * time.Second
+	maxDelay := 1 * time.Minute
+	factor := 2.0
+	currentDelay := baseDelay
+
+	retries := 0
+
 	for {
 		err := c.authenticate(ctx)
 		if err == nil {
-			return
+			return nil
 		}
-		c.config.Logger.Errorf("Authentication failed. Trying again in 1 minute: %s", err)
-		time.Sleep(1 * time.Minute)
+		retries++
+
+		var nonRetryableAuthError NonRetryableAuthError
+		if errors.As(err, &nonRetryableAuthError) {
+			c.config.Logger.Error("Authentication failed with a non-retryable error: '%s %s' Default variations will now be served", nonRetryableAuthError.StatusCode, nonRetryableAuthError.Message)
+			return err
+		}
+
+		// -1 is the default maxAuthRetries option and indicates there should be no max retries
+		if c.config.maxAuthRetries != -1 && retries >= c.config.maxAuthRetries {
+			c.config.Logger.Errorf("Authentication failed with error: '%s'. Exceeded max retries '%s'.", err, c.config.maxAuthRetries)
+			return err
+		}
+
+		jitter := time.Duration(rand.Float64() * float64(currentDelay))
+		delayWithJitter := currentDelay + jitter
+
+		c.config.Logger.Errorf("Authentication failed with error: '%s'. Retrying in %v.", err, delayWithJitter)
+		time.Sleep(delayWithJitter)
+
+		currentDelay *= time.Duration(factor)
+		if currentDelay > maxDelay {
+			currentDelay = maxDelay
+		}
+
 	}
 }
 
@@ -262,9 +321,31 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// should be login to harness and get account data (JWT token)
+
+	responseError := findErrorInResponse(response)
+
+	// Indicate that we should retry
+	if responseError != nil && responseError.Code == "500" {
+		return RetryableAuthError{
+			StatusCode: responseError.Code,
+			Message:    responseError.Message,
+		}
+	}
+
+	// Indicate that we shouldn't retry on non-500 errors
+	if responseError != nil {
+		return NonRetryableAuthError{
+			StatusCode: responseError.Code,
+			Message:    responseError.Message,
+		}
+	}
+
+	// Defensive check to handle the case that all responses are nil
 	if response.JSON200 == nil {
-		return fmt.Errorf("error while authenticating %v", ErrUnauthorized)
+		return RetryableAuthError{
+			StatusCode: "No errpr status code returned from server",
+			Message:    "No error message returned from server ",
+		}
 	}
 
 	c.token = response.JSON200.AuthToken
@@ -427,6 +508,10 @@ func (c *CfClient) setAnalyticsServiceClient(ctx context.Context) {
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultValue bool) (bool, error) {
+	if !c.initializedBool {
+		c.config.Logger.Error("Error when calling BoolVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.BoolVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -435,6 +520,10 @@ func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultV
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaultValue string) (string, error) {
+	if !c.initializedBool {
+		c.config.Logger.Error("Error when calling StringVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.StringVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -443,6 +532,10 @@ func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaul
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultValue int64) (int64, error) {
+	if !c.initializedBool {
+		c.config.Logger.Error("Error when calling IntVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.IntVariation(key, target, int(defaultValue))
 	return int64(value), nil
 }
@@ -451,6 +544,10 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaultValue float64) (float64, error) {
+	if !c.initializedBool {
+		c.config.Logger.Error("Error when calling NumberVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.NumberVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -460,6 +557,10 @@ func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaul
 //
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultValue types.JSON) (types.JSON, error) {
+	if !c.initializedBool {
+		c.config.Logger.Error("Error when calling JSONVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, nil
+	}
 	value := c.evaluator.JSONVariation(key, target, defaultValue)
 	return value, nil
 }
@@ -467,6 +568,9 @@ func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultV
 // Close shuts down the Feature Flag client. After calling this, the client
 // should no longer be used
 func (c *CfClient) Close() error {
+	if !c.initializedBool {
+		return errors.New("attempted to close client that is not initialized")
+	}
 	if c.stopped.get() {
 		return errors.New("client already closed")
 	}
@@ -525,4 +629,14 @@ func getLogger(options ...ConfigOption) logger.Logger {
 		dummyConfig.Logger = defaultLogger
 	}
 	return dummyConfig.Logger
+}
+
+func findErrorInResponse(resp *rest.AuthenticateResponse) *rest.Error {
+	responseErrors := []*rest.Error{resp.JSON401, resp.JSON403, resp.JSON404, resp.JSON500}
+	for _, responseError := range responseErrors {
+		if responseError != nil {
+			return responseError
+		}
+	}
+	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -91,7 +91,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 
 	if sdkKey == "" {
 		config.Logger.Errorf("Initialization failed: SDK Key cannot be empty. Please provide a valid SDK Key to initialize the client.")
-		return client, types.ErrSdkCantBeEmpty
+		return client, EmptySDKKeyError
 	}
 
 	var err error
@@ -512,8 +512,8 @@ func (c *CfClient) setAnalyticsServiceClient(ctx context.Context) {
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultValue bool) (bool, error) {
 	if !c.initializedBool {
-		c.config.Logger.Error("Error when calling BoolVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, nil
+		c.config.Logger.Info("Error when calling BoolVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, fmt.Errorf("%w", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.BoolVariation(key, target, defaultValue)
 	return value, nil
@@ -524,8 +524,8 @@ func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultV
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaultValue string) (string, error) {
 	if !c.initializedBool {
-		c.config.Logger.Error("Error when calling StringVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, nil
+		c.config.Logger.Info("Error when calling StringVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, fmt.Errorf("%w: Client is not initialized", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.StringVariation(key, target, defaultValue)
 	return value, nil
@@ -536,8 +536,8 @@ func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaul
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultValue int64) (int64, error) {
 	if !c.initializedBool {
-		c.config.Logger.Error("Error when calling IntVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, nil
+		c.config.Logger.Info("Error when calling IntVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, fmt.Errorf("%w: Client is not initialized", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.IntVariation(key, target, int(defaultValue))
 	return int64(value), nil
@@ -548,8 +548,8 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaultValue float64) (float64, error) {
 	if !c.initializedBool {
-		c.config.Logger.Error("Error when calling NumberVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, nil
+		c.config.Logger.Info("Error when calling NumberVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, fmt.Errorf("%w: Client is not initialized", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.NumberVariation(key, target, defaultValue)
 	return value, nil
@@ -561,8 +561,8 @@ func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaul
 // Returns defaultValue if there is an error or if the flag doesn't exist
 func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultValue types.JSON) (types.JSON, error) {
 	if !c.initializedBool {
-		c.config.Logger.Error("Error when calling JSONVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, nil
+		c.config.Logger.Info("Error when calling JSONVariation and returning default variation: 'Client is not initialized'")
+		return defaultValue, fmt.Errorf("%w: Client is not initialized", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.JSONVariation(key, target, defaultValue)
 	return value, nil

--- a/client/client.go
+++ b/client/client.go
@@ -181,16 +181,6 @@ func (c *CfClient) IsInitialized() (bool, error) {
 	return false, InitializeTimeoutError{}
 }
 
-// checkInitializedStatus returns a boolean indicating whether the CfClient
-// is initialized at the time the method is called. If the client is being
-// created in asynchronous mode, this method may return false even if the
-// initialization is in progress. In other words, a false value does not
-// necessarily indicate a failure but may indicate that initialization is
-// still underway.
-func (c *CfClient) checkInitializedStatus() bool {
-	return c.initializedBool
-}
-
 func (c *CfClient) retrieve(ctx context.Context) bool {
 	ok := true
 	var wg sync.WaitGroup

--- a/client/client.go
+++ b/client/client.go
@@ -513,7 +513,7 @@ func (c *CfClient) setAnalyticsServiceClient(ctx context.Context) {
 func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultValue bool) (bool, error) {
 	if !c.initializedBool {
 		c.config.Logger.Info("Error when calling BoolVariation and returning default variation: 'Client is not initialized'")
-		return defaultValue, fmt.Errorf("%w", DefaultVariationReturnedError)
+		return defaultValue, fmt.Errorf("%w: Client is not initialized", DefaultVariationReturnedError)
 	}
 	value := c.evaluator.BoolVariation(key, target, defaultValue)
 	return value, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -714,12 +714,4 @@ func TestCfClient_Close(t *testing.T) {
 
 	t.Log("When I close the client for the second time I should an error")
 	assert.NotNil(t, client.Close())
-
-	t.Log("When I close the client before it's been initialized I should get an error")
-
-	client2, err := newClient(&http.Client{}, ValidSDKKey)
-	if err != nil {
-		t.Error(err)
-	}
-	assert.NotNil(t, client2.Close())
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -141,26 +141,6 @@ func TestCfClient_NewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "Asynchronous client: Authentication failed with 401 and no retry, times out waiting",
-			newClientFunc: func() (*CfClient, error) {
-				client, err := newClient(http.DefaultClient, InvaliDSDKKey, WithSleeper(test_helpers.MockSleeper{}))
-				if ok, err := client.IsInitialized(); !ok {
-					return client, err
-				}
-				return client, err
-			},
-			mockResponder: func() {
-				bodyString := `{
-				"message": "invalid key or target provided",
-				"code": "401"
-				}`
-				authErrorResponse := AuthResponseDetailed(401, "401", bodyString)
-				registerResponders(authErrorResponse, TargetSegmentsResponse, FeatureConfigsResponse)
-			},
-			// An async client cannot return an error for auth failures due
-			err: InitializeTimeoutError{},
-		},
-		{
 			name: "Synchronous client: Authentication failed with 403 and no retry",
 			newClientFunc: func() (*CfClient, error) {
 				return newClient(http.DefaultClient, ValidSDKKey, WithWaitForInitialized(true))
@@ -305,6 +285,26 @@ func TestCfClient_NewClient(t *testing.T) {
 			},
 			mockResponder: nil,
 			err:           InitializeTimeoutError{},
+		},
+		{
+			name: "Asynchronous client: Authentication failed with 401 and no retry, times out waiting",
+			newClientFunc: func() (*CfClient, error) {
+				client, err := newClient(http.DefaultClient, InvaliDSDKKey, WithSleeper(test_helpers.MockSleeper{}))
+				if ok, err := client.IsInitialized(); !ok {
+					return client, err
+				}
+				return client, err
+			},
+			mockResponder: func() {
+				bodyString := `{
+				"message": "invalid key or target provided",
+				"code": "401"
+				}`
+				authErrorResponse := AuthResponseDetailed(401, "401", bodyString)
+				registerResponders(authErrorResponse, TargetSegmentsResponse, FeatureConfigsResponse)
+			},
+			// An async client cannot return an error for auth failures due
+			err: InitializeTimeoutError{},
 		},
 		{
 			name: "Asynchronous client: Authentication failed with 403 and no retry, times out waiting",
@@ -473,7 +473,7 @@ func TestCfClient_BoolVariation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			flag, err := client.BoolVariation(test.args.key, test.args.target, test.args.defaultValue)
 			if (err != nil) != test.wantErr {
-				t.Errorf("BoolVariation() error = %v, err %v", err, test.wantErr)
+				t.Errorf("BoolVariation() error = %v, wanrErr %v", err, test.wantErr)
 				return
 			}
 			assert.Equal(t, test.want, flag, "%s didn't get expected value", test.name)
@@ -512,7 +512,7 @@ func TestCfClient_StringVariation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			flag, err := client.StringVariation(test.args.key, test.args.target, test.args.defaultValue)
 			if (err != nil) != test.wantErr {
-				t.Errorf("BoolVariation() error = %v, err %v", err, test.wantErr)
+				t.Errorf("BoolVariation() error = %v, wanrErr %v", err, test.wantErr)
 				return
 			}
 			assert.Equal(t, test.want, flag, "%s didn't get expected value", test.name)
@@ -722,7 +722,7 @@ var AuthResponseDetailed = func(statusCode int, status string, bodyString string
 		response := &http.Response{
 			StatusCode: statusCode,
 			Status:     status,
-			Body:       io.NopCloser(bytes.NewReader([]byte(bodyString))), // this is your JSON body as io.ReadCloser
+			Body:       io.NopCloser(bytes.NewReader([]byte(bodyString))),
 			Header:     make(http.Header),
 		}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"github.com/harness/ff-golang-server-sdk/dto"
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 	"github.com/harness/ff-golang-server-sdk/log"
@@ -119,7 +120,7 @@ func TestCfClient_NewClient(t *testing.T) {
 				return newClient(http.DefaultClient, EmptySDKKey, WithWaitForInitialized(true))
 			},
 			mockResponder: nil,
-			err:           types.ErrSdkCantBeEmpty,
+			err:           EmptySDKKeyError,
 		},
 		{
 			name: "Synchronous client: Authentication failed with 401 and no retry",
@@ -453,6 +454,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 		expectedInt    int64
 		expectedNumber float64
 		expectedJSON   types.JSON
+		expectedError  error
 	}{
 		{
 			name: "Evaluations with Synchronous client with empty SDK key",
@@ -464,6 +466,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Synchronous client with invalid SDK key",
@@ -483,6 +486,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Synchronous client with a server error",
@@ -502,6 +506,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Synchronous client with empty SDK key",
@@ -513,6 +518,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Async client with invalid SDK key",
@@ -532,6 +538,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Async client with a server error",
@@ -551,6 +558,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 		{
 			name: "Evaluations with Async client with empty SDK key",
@@ -562,6 +570,7 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 			expectedInt:    45555,
 			expectedNumber: 45.222,
 			expectedJSON:   types.JSON{"a default key": "a default value"},
+			expectedError:  DefaultVariationReturnedError,
 		},
 	}
 	target := target()
@@ -575,23 +584,23 @@ func TestCfClient_DefaultVariationReturned(t *testing.T) {
 
 			boolResult, err := client.BoolVariation("TestTrueOn", target, false)
 			assert.Equal(t, tt.expectedBool, boolResult)
-			assert.Nil(t, err)
+			assert.True(t, errors.Is(err, tt.expectedError))
 
 			stringResult, err := client.StringVariation("TestTrueOn", target, "a default value")
 			assert.Equal(t, tt.expectedString, stringResult)
-			assert.Nil(t, err)
+			assert.True(t, errors.Is(err, tt.expectedError))
 
 			intResult, err := client.IntVariation("TestTrueOn", target, tt.expectedInt)
 			assert.Equal(t, tt.expectedInt, intResult)
-			assert.Nil(t, err)
+			assert.True(t, errors.Is(err, tt.expectedError))
 
 			numerResult, err := client.NumberVariation("TestTrueOn", target, tt.expectedNumber)
 			assert.Equal(t, tt.expectedNumber, numerResult)
-			assert.Nil(t, err)
+			assert.True(t, errors.Is(err, tt.expectedError))
 
 			jsonResult, _ := client.JSONVariation("TestTrueOn", target, tt.expectedJSON)
 			assert.Equal(t, tt.expectedJSON, jsonResult)
-			assert.Nil(t, err)
+			assert.True(t, errors.Is(err, tt.expectedError))
 		})
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -34,8 +34,8 @@ type responderQueue struct {
 	index      int
 }
 
-// makeResponderQueue creates a new instance of responderQueue with the provided responders
-func makeResponderQueue(responders []httpmock.Responder) *responderQueue {
+// newResponderQueue creates a new instance of responderQueue with the provided responders
+func newResponderQueue(responders []httpmock.Responder) *responderQueue {
 	return &responderQueue{
 		responders: responders,
 		index:      0,
@@ -70,7 +70,7 @@ func registerResponders(authResponder httpmock.Responder, targetSegmentsResponde
 
 // Same as registerResponders except the auth response can be different per call
 func registerMultipleResponseResponders(authResponder []httpmock.Responder, targetSegmentsResponder httpmock.Responder, featureConfigsResponder httpmock.Responder) {
-	authQueue := makeResponderQueue(authResponder)
+	authQueue := newResponderQueue(authResponder)
 	httpmock.RegisterResponder("POST", "http://localhost/api/1.0/client/auth", authQueue.getNextResponder)
 
 	// These responders don't need different responses per call

--- a/client/config.go
+++ b/client/config.go
@@ -27,6 +27,8 @@ type config struct {
 	eventStreamListener stream.EventStreamListener
 	enableAnalytics     bool
 	proxyMode           bool
+	waitForInitialized  bool
+	maxAuthRetries      int
 }
 
 func newDefaultConfig(log logger.Logger) *config {
@@ -52,5 +54,7 @@ func newDefaultConfig(log logger.Logger) *config {
 		enableStore:     true,
 		enableAnalytics: true,
 		proxyMode:       false,
+		// Indicate that we should retry forever by default
+		maxAuthRetries: -1,
 	}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -1,11 +1,11 @@
 package client
 
 import (
-	"net/http"
-	"os"
-
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 	"github.com/harness/ff-golang-server-sdk/stream"
+	"github.com/harness/ff-golang-server-sdk/types"
+	"net/http"
+	"os"
 
 	"github.com/harness/ff-golang-server-sdk/cache"
 	"github.com/harness/ff-golang-server-sdk/logger"
@@ -29,6 +29,7 @@ type config struct {
 	proxyMode           bool
 	waitForInitialized  bool
 	maxAuthRetries      int
+	sleeper             types.Sleeper
 }
 
 func newDefaultConfig(log logger.Logger) *config {
@@ -56,5 +57,6 @@ func newDefaultConfig(log logger.Logger) *config {
 		proxyMode:       false,
 		// Indicate that we should retry forever by default
 		maxAuthRetries: -1,
+		sleeper:        &types.RealClock{},
 	}
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,8 +1,21 @@
 package client
 
-import "errors"
+import "fmt"
 
-var (
-	// ErrUnauthorized displays error message for unauthorized users
-	ErrUnauthorized = errors.New("unauthorized")
-)
+type NonRetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e NonRetryableAuthError) Error() string {
+	return fmt.Sprintf("unauthorized: %s: %s", e.StatusCode, e.Message)
+}
+
+type RetryableAuthError struct {
+	StatusCode string
+	Message    string
+}
+
+func (e RetryableAuthError) Error() string {
+	return fmt.Sprintf("server error: %s: %s", e.StatusCode, e.Message)
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -19,3 +19,10 @@ type RetryableAuthError struct {
 func (e RetryableAuthError) Error() string {
 	return fmt.Sprintf("server error: %s: %s", e.StatusCode, e.Message)
 }
+
+type InitializeTimeoutError struct {
+}
+
+func (e InitializeTimeoutError) Error() string {
+	return fmt.Sprintf("timeout waiting to initialize")
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,6 +1,13 @@
 package client
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var DefaultVariationReturnedError = errors.New("default variation was returned")
+
+var EmptySDKKeyError = errors.New("default variation was returned")
 
 type NonRetryableAuthError struct {
 	StatusCode string

--- a/client/options.go
+++ b/client/options.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"net/http"
-
 	"github.com/harness/ff-golang-server-sdk/cache"
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 	"github.com/harness/ff-golang-server-sdk/logger"
 	"github.com/harness/ff-golang-server-sdk/storage"
 	"github.com/harness/ff-golang-server-sdk/stream"
+	"github.com/harness/ff-golang-server-sdk/types"
+	"net/http"
 )
 
 // ConfigOption is used as return value for advanced client configuration
@@ -121,5 +121,11 @@ func WithWaitForInitialized(b bool) ConfigOption {
 func WithMaxAuthRetries(i int) ConfigOption {
 	return func(config *config) {
 		config.maxAuthRetries = i
+	}
+}
+
+func WithSleeper(sleeper types.Sleeper) ConfigOption {
+	return func(config *config) {
+		config.sleeper = sleeper
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -111,3 +111,15 @@ func WithProxyMode(b bool) ConfigOption {
 		config.proxyMode = b
 	}
 }
+
+func WithWaitForInitialized(b bool) ConfigOption {
+	return func(config *config) {
+		config.waitForInitialized = b
+	}
+}
+
+func WithMaxAuthRetries(i int) ConfigOption {
+	return func(config *config) {
+		config.maxAuthRetries = i
+	}
+}

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -16,13 +16,15 @@ client, err := harness.NewCfClient(myApiKey,
 
 ```
 
-| Name            | Config Option                                                  | Description                                                                                                                                      | default                              |
-|-----------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| baseUrl         | harness.WithURL("https://config.ff.harness.io/api/1.0")        | the URL used to fetch feature flag evaluations. You should change this when using the Feature Flag proxy to http://localhost:7000                | https://config.ff.harness.io/api/1.0 |
-| eventsUrl       | harness.WithEventsURL("https://events.ff.harness.io/api/1.0"), | the URL used to post metrics data to the feature flag service. You should change this when using the Feature Flag proxy to http://localhost:7000 | https://events.ff.harness.io/api/1.0 |
-| pollInterval    | harness.WithPullInterval(60))                                  | when running in stream mode, the interval in seconds that we poll for changes.                                                                   | 1                                   |
-| enableStream    | harness.WithStreamEnabled(false),                              | Enable streaming mode.                                                                                                                           | true                                 |
-| enableAnalytics | *Not Supported*                                                | Enable analytics.  Metrics data is posted every 60s                                                                                              | *Not Supported*                      |
+| Name               | Config Option                                                  | Description                                                                                                                                      | default                              |
+|--------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| baseUrl            | harness.WithURL("https://config.ff.harness.io/api/1.0")        | the URL used to fetch feature flag evaluations. You should change this when using the Feature Flag proxy to http://localhost:7000                | https://config.ff.harness.io/api/1.0 |
+| eventsUrl          | harness.WithEventsURL("https://events.ff.harness.io/api/1.0"), | the URL used to post metrics data to the feature flag service. You should change this when using the Feature Flag proxy to http://localhost:7000 | https://events.ff.harness.io/api/1.0 |
+| pollInterval       | harness.WithPullInterval(60))                                  | when running in stream mode, the interval in seconds that we poll for changes.                                                                   | 1                                    |
+| enableStream       | harness.WithStreamEnabled(false),                              | Enable streaming mode.                                                                                                                           | true                                 |
+| waitForInitialized | harness.WithWaitForInitialized(true)                           | When calling `NewCfClient` , will not return `client, err` until initialization succeeds of fails                                                | false                                |
+| maxAuthRetries     | harness.WithMaxAuthRetries(5)                                  | The maximum number of attempts that the client will try to authenticate on errors that it deems are retryable.                                   | unlimited                            |
+| enableAnalytics    | *Not Supported*                                                | Enable analytics.  Metrics data is posted every 60s                                                                                              | *Not Supported*                      |
 
 ## Logging Configuration
 You can provide your own logger to the SDK, passing it in as a config option.

--- a/examples/getting_started.go
+++ b/examples/getting_started.go
@@ -45,7 +45,7 @@ func main() {
 	for {
 		resultBool, err := client.BoolVariation(flagName, &target, false)
 		if err != nil {
-			log.Fatal("failed to get evaluation: ", err)
+			log.Printf("failed to get evaluation: %v ", err)
 		}
 		log.Printf("Flag variation %v\n", resultBool)
 

--- a/examples/getting_started.go
+++ b/examples/getting_started.go
@@ -19,7 +19,7 @@ func main() {
 
 	// Create a feature flag client and wait for it to successfully initialize
 	startTime := time.Now()
-	client, err := harness.NewCfClient(sdkKey, harness.WithWaitForInitialized(false))
+	client, err := harness.NewCfClient(sdkKey, harness.WithWaitForInitialized(true))
 	elapsedTime := time.Since(startTime)
 	log.Printf("Took '%v' seconds to get a client initialization result ", elapsedTime.Seconds())
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ff-golang-server-sdk
 
-go 1.19
+go 1.18
 
 require (
 	github.com/deepmap/oapi-codegen v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ff-golang-server-sdk
 
-go 1.18
+go 1.19
 
 require (
 	github.com/deepmap/oapi-codegen v1.11.0

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -1,12 +1,16 @@
-package client_test
+package test_helpers
 
 import (
 	"fmt"
-	"net/http"
-
 	"github.com/harness/ff-golang-server-sdk/rest"
 	"github.com/jarcoal/httpmock"
+	"net/http"
+	"time"
 )
+
+func Cool() {
+
+}
 
 func MakeBoolFeatureConfigs(name, defaultVariation, offVariation, state string, preReqs ...rest.Prerequisite) []rest.FeatureConfig {
 	var featureConfig []rest.FeatureConfig
@@ -111,6 +115,10 @@ func MakeStringFeatureConfig(name, defaultVariation, offVariation, state string,
 	}
 }
 
+func JsonError(err error) (*http.Response, error) {
+	return httpmock.NewJsonResponse(500, fmt.Errorf(`{"error" : "%s"}`, err))
+}
+
 func intPtr(value int64) *int64 {
 	return &value
 }
@@ -119,6 +127,9 @@ func strPtr(value string) *string {
 	return &value
 }
 
-func jsonError(err error) (*http.Response, error) {
-	return httpmock.NewJsonResponse(500, fmt.Errorf(`{"error" : "%s"}`, err))
+type MockSleeper struct {
+}
+
+func (ms MockSleeper) Sleep(d time.Duration) {
+	time.Sleep(0)
 }

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -8,10 +8,6 @@ import (
 	"time"
 )
 
-func Cool() {
-
-}
-
 func MakeBoolFeatureConfigs(name, defaultVariation, offVariation, state string, preReqs ...rest.Prerequisite) []rest.FeatureConfig {
 	var featureConfig []rest.FeatureConfig
 	featureConfig = append(featureConfig, MakeBoolFeatureConfig(name, defaultVariation, offVariation, state, preReqs))
@@ -66,35 +62,6 @@ func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string
 
 	return featureConfig
 }
-
-/*
-{
-		"defaultServe": {
-			"variation": "Alpha"
-		},
-		"environment": "PreProduction",
-		"feature": "TestStringFlag",
-		"kind": "string",
-		"offVariation": "Bravo",
-		"prerequisites": [],
-		"project": "Customer_Self_Service_Portal",
-		"rules": [],
-		"state": "off",
-		"variations": [
-			{
-				"identifier": "Alpha",
-				"name": "Bravo",
-				"value": "A"
-			},
-			{
-				"identifier": "Bravo",
-				"name": "Bravo",
-				"value": "B"
-			}
-		],
-		"version": 1
-	}
-*/
 
 func MakeStringFeatureConfig(name, defaultVariation, offVariation, state string, preReqs []rest.Prerequisite) rest.FeatureConfig {
 	return rest.FeatureConfig{

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -128,8 +128,9 @@ func strPtr(value string) *string {
 }
 
 type MockSleeper struct {
+	SleepTime time.Duration
 }
 
 func (ms MockSleeper) Sleep(d time.Duration) {
-	time.Sleep(0)
+	time.Sleep(ms.SleepTime)
 }

--- a/types/clock.go
+++ b/types/clock.go
@@ -1,0 +1,14 @@
+package types
+
+import "time"
+
+type Sleeper interface {
+	Sleep(time.Duration)
+}
+
+// RealClock is the default implementation for Sleeper
+type RealClock struct{}
+
+func (rc RealClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}

--- a/types/error.go
+++ b/types/error.go
@@ -8,8 +8,6 @@ func (e ErrorType) Error() string {
 }
 
 const (
-	// ErrSdkCantBeEmpty represent error when no SDK key found in client api
-	ErrSdkCantBeEmpty = ErrorType("Sdk can't be empty!")
 	// ErrWrongTypeAssertion is custom error for wrong type assertions
 	ErrWrongTypeAssertion = ErrorType("Wrong type assertion")
 )


### PR DESCRIPTION
# What
This PR does the following

1. Adds a `WaitForInitialized` option which uses a channel approach, improving upon the `IsInitialized` method. 
`IsInitialized` can still be used for backwards compatibility.  
    - if an error occurs during initialization, it will be returned to the caller along with a non-nil `client`. If any variation functions are called in this state an error will be logged and the default variation returned. If `close` is attempted to be called, an error will be logged and returned. 

2. Changes how client authentication retries are handled. Instead of retrying on all errors, forever:
    - `WithMaxAuthRetries` option is available. Defaults to unlimited retries (if the error is retryable).
    - Only retry on 500 errors
    - Uses backoff/jitter

# Testing
1. New unit tests for synchronous and asynchronous client init, testing the new 
    - Auth retry behaviour
    - `WithWaitForInitialized` 
    - `IsInitialized` 
    - Standard client init with no waiting

2. New unit tests for `XVariation` and `Close` being called in an unitialized state. 

3. Manual testing: 
    - Sample application with both `WaitForInitialized` and IsInitialized`
    - Toggle flags in streaming mode
    - Toggle flags in polling mode
    - Closing client

3. TestGrid image update 
    - Use `WaitForInitialized` to init the client - all scenarios passed
    - Use `IsInitialized` to init the client - all scenarios passed
