### PR TITLE
FFM-7010 Use SDK HTTP Client for all requests

### DIFF
--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -25,7 +25,7 @@ const (
 	variationValueAttribute      string = "featureValue"
 	targetAttribute              string = "target"
 	sdkVersionAttribute          string = "SDK_VERSION"
-	sdkVersion                   string = "1.12.0"
+	sdkVersion                   string = "0.1.14"
 	sdkTypeAttribute             string = "SDK_TYPE"
 	sdkType                      string = "server"
 	sdkLanguageAttribute         string = "SDK_LANGUAGE"

--- a/client/client.go
+++ b/client/client.go
@@ -244,6 +244,9 @@ func (c *CfClient) streamConnect(ctx context.Context) {
 	c.config.Logger.Info("Registering SSE consumer")
 	sseClient := sse.NewClient(fmt.Sprintf("%s/stream?cluster=%s", c.config.url, c.clusterIdentifier))
 
+	// Use the SDKs http client
+	sseClient.Connection = c.config.httpClient
+
 	streamErr := func() {
 		c.config.Logger.Warnf("%s Stream disconnected. Swapping to polling mode", sdk_codes.StreamDisconnected)
 		c.mux.RLock()
@@ -400,7 +403,7 @@ func (c *CfClient) authenticate(ctx context.Context) error {
 	metricsClient, err := metricsclient.NewClientWithResponses(c.config.eventsURL,
 		metricsclient.WithRequestEditorFn(bearerTokenProvider.Intercept),
 		metricsclient.WithRequestEditorFn(c.InterceptAddCluster),
-		metricsclient.WithHTTPClient(http.DefaultClient),
+		metricsclient.WithHTTPClient(c.config.httpClient),
 	)
 	if err != nil {
 		return err

--- a/examples/tls/example.go
+++ b/examples/tls/example.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	harness "github.com/harness/ff-golang-server-sdk/client"
+	"github.com/harness/ff-golang-server-sdk/evaluation"
+)
+
+var (
+	flagName string = getEnvOrDefault("FF_FLAG_NAME", "harnessappdemodarkmode")
+	sdkKey   string = getEnvOrDefault("FF_API_KEY", "change me")
+)
+
+func main() {
+	log.Println("Harness SDK Getting Started")
+
+	certPool, err := loadCertificates([]string{"path to PEM", "path to PEM"})
+	if err != nil {
+		log.Printf("Failed to parse PEM files: `%s`\n", err)
+	}
+
+	// Create a custom TLS configuration and use the CA pool.
+	tlsConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	httpClient := http.Client{Transport: transport}
+
+	// Create a feature flag client and wait for it to successfully initialize
+	startTime := time.Now()
+
+	// Note that this code uses ffserver hostname as an example, likely you'll have your own hostname or IP.
+	// You should ensure the endpoint is returning a cert with valid SANs configured for the host/IP.
+	client, err := harness.NewCfClient(sdkKey, harness.WithEventsURL("https://ffserver:8001/api/1.0"), harness.WithURL("https://ffserver:8001/api/1.0"), harness.WithWaitForInitialized(true), harness.WithHTTPClient(&httpClient))
+
+	elapsedTime := time.Since(startTime)
+	log.Printf("Took '%v' seconds to get a client initialization result ", elapsedTime.Seconds())
+
+	if err != nil {
+		log.Printf("Client failed to initialize: `%s`\n", err)
+	}
+
+	defer func() {
+		err := client.Close()
+		if err != nil {
+			return
+		}
+	}()
+
+	// Create a target (different targets can get different results based on rules)
+	target := evaluation.Target{
+		Identifier: "HT_1",
+		Name:       "Harness_Target_1",
+		Attributes: &map[string]interface{}{"email": "demo@harness.io"},
+	}
+
+	// Loop forever reporting the state of the flag
+	for {
+		resultBool, err := client.BoolVariation(flagName, &target, false)
+		if err != nil {
+			log.Printf("failed to get evaluation: %v ", err)
+		}
+		log.Printf("Flag variation %v\n", resultBool)
+
+		time.Sleep(10 * time.Second)
+	}
+
+}
+
+func getEnvOrDefault(key, defaultStr string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultStr
+	}
+	return value
+}
+
+// Load certificates from PEM files
+func loadCertificates(filePaths []string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, ca := range filePaths {
+		var caBytes []byte
+		var err error
+		caBytes, err = os.ReadFile(ca)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate from file: %w", err)
+		}
+
+		if !pool.AppendCertsFromPEM(caBytes) {
+			return nil, fmt.Errorf("could not append CA certificate")
+		}
+	}
+	return pool, nil
+}

--- a/examples/tls/example.go
+++ b/examples/tls/example.go
@@ -19,7 +19,7 @@ var (
 )
 
 func main() {
-	log.Println("Harness SDK Getting Started")
+	log.Println("Harness SDK TLS Example")
 
 	certPool, err := loadCertificates([]string{"path to PEM", "path to PEM"})
 	if err != nil {

--- a/examples/tls/example.go
+++ b/examples/tls/example.go
@@ -21,7 +21,7 @@ var (
 func main() {
 	log.Println("Harness SDK TLS Example")
 
-	certPool, err := loadCertificates([]string{"path to PEM", "path to PEM"})
+	certPool, err := loadCertificates([]string{"/Users/erowlands/Documents/andytlscerts/CA.crt"})
 	if err != nil {
 		log.Printf("Failed to parse PEM files: `%s`\n", err)
 	}
@@ -42,7 +42,7 @@ func main() {
 
 	// Note that this code uses ffserver hostname as an example, likely you'll have your own hostname or IP.
 	// You should ensure the endpoint is returning a cert with valid SANs configured for the host/IP.
-	client, err := harness.NewCfClient(sdkKey, harness.WithEventsURL("https://ffserver:8001/api/1.0"), harness.WithURL("https://ffserver:8001/api/1.0"), harness.WithWaitForInitialized(true), harness.WithHTTPClient(&httpClient))
+	client, err := harness.NewCfClient(sdkKey, harness.WithEventsURL("https://ffserver:8003/api/1.0"), harness.WithURL("https://ffserver:8003/api/1.0"), harness.WithWaitForInitialized(true), harness.WithHTTPClient(&httpClient))
 
 	elapsedTime := time.Since(startTime)
 	log.Printf("Took '%v' seconds to get a client initialization result ", elapsedTime.Seconds())
@@ -90,9 +90,7 @@ func getEnvOrDefault(key, defaultStr string) string {
 func loadCertificates(filePaths []string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	for _, ca := range filePaths {
-		var caBytes []byte
-		var err error
-		caBytes, err = os.ReadFile(ca)
+		caBytes, err := os.ReadFile(ca)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA certificate from file: %w", err)
 		}

--- a/examples/tls/example.go
+++ b/examples/tls/example.go
@@ -21,7 +21,7 @@ var (
 func main() {
 	log.Println("Harness SDK TLS Example")
 
-	certPool, err := loadCertificates([]string{"/Users/erowlands/Documents/andytlscerts/CA.crt"})
+	certPool, err := loadCertificates([]string{"path to PEM", "path to PEM"})
 	if err != nil {
 		log.Printf("Failed to parse PEM files: `%s`\n", err)
 	}


### PR DESCRIPTION
# What

Uses the existing `WithHttpClient` option to provide custom TLS support.

- Now uses overridden  http client for metrics and SSE 
- Adds TLS example

# Testing
- Custom CAs using local proxy
    - Authentication
    - Requests to features endpoint
    - Streaming
    - Metrics
- No custom http client/custom CAs provided. 