### PR TITLE
[FFM-10027] - Fall back to identifier if bucketBy attribute is not found

### DIFF
--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -25,7 +25,7 @@ const (
 	variationValueAttribute      string = "featureValue"
 	targetAttribute              string = "target"
 	sdkVersionAttribute          string = "SDK_VERSION"
-	SdkVersion                   string = "0.1.16"
+	SdkVersion                   string = "0.1.17"
 	sdkTypeAttribute             string = "SDK_TYPE"
 	sdkType                      string = "server"
 	sdkLanguageAttribute         string = "SDK_LANGUAGE"

--- a/evaluation/util_test.go
+++ b/evaluation/util_test.go
@@ -26,7 +26,7 @@ func Test_getAttrValueIsNil(t *testing.T) {
 			want: reflect.Value{},
 		},
 		{
-			name: "wrong attribute should return Value{}",
+			name: "wrong attribute should return ValueOf('')",
 			args: args{
 				target: &Target{
 					Identifier: harness,
@@ -36,7 +36,7 @@ func Test_getAttrValueIsNil(t *testing.T) {
 				},
 				attr: "no_identifier",
 			},
-			want: reflect.Value{},
+			want: reflect.ValueOf(""),
 		},
 	}
 	for _, tt := range tests {

--- a/sdk_codes/sdk_codes.go
+++ b/sdk_codes/sdk_codes.go
@@ -24,6 +24,7 @@ const (
 	StreamStop         SDKCode = "SDKCODE:5004"
 	EvaluationSuccess  SDKCode = "SDKCODE:6000"
 	EvaluationFailed   SDKCode = "SDKCODE:6001"
+	MissingBucketBy    SDKCode = "SDKCODE:6002"
 	MetricsStarted     SDKCode = "SDKCODE:7000"
 	MetricsStopped     SDKCode = "SDKCODE:7001"
 	MetricsSendFail    SDKCode = "SDKCODE:7002"


### PR DESCRIPTION
[FFM-10027] - Fall back to 'identifier' if bucketBy attribute is not found

What
Update BucketBy logic to fall back to the target's identifier if given BucketBy attribute is not found.

Why
Keep the SDK consistent with the behaviour of the other server SDKs.

Testing
Testgrid + manual

[FFM-10027]: https://harness.atlassian.net/browse/FFM-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ