### PR TITLE
FFM-11006 Add Connection close header

### DIFF
--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -36,7 +36,7 @@ pipeline:
                   identifier: Submodule_Init
                   spec:
                     connectorRef: DockerHub
-                    image: golang:1.18.6
+                    image: golang:1.19.9
                     shell: Sh
                     command: "mkdir -p ~/.ssh\nssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts\n\ncat <<EOF >> .gitmodules\n[submodule \"tests/ff-test-cases\"]\n\tpath = tests/ff-test-cases\n\turl = https://github.com/drone/ff-test-cases.git\nEOF\n\ngit submodule update --init --recursive"
               - parallel:
@@ -46,7 +46,7 @@ pipeline:
                       identifier: Build_and_Test
                       spec:
                         connectorRef: DockerHub
-                        image: golang:1.18.6
+                        image: golang:1.19.9
                         shell: Sh
                         command: |-
                           go install github.com/jstemmer/go-junit-report@latest

--- a/client/transport.go
+++ b/client/transport.go
@@ -3,7 +3,7 @@ package client
 import "net/http"
 
 // HeadersFn is a function type that provides headers dynamically.
-type HeadersFn func() (map[string]string, error)
+type HeadersFn func(r *http.Request) (map[string]string, error)
 
 // customTransport wraps an http.RoundTripper and allows adding headers dynamically. This means we can still use
 // the goretryable-http client's transport, or a user's transport if they've provided their own http client.
@@ -22,7 +22,7 @@ func NewCustomTransport(baseTransport http.RoundTripper, getHeaderFn HeadersFn) 
 
 func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Retrieve the headers using the provided function.
-	headers, err := t.getHeaders()
+	headers, err := t.getHeaders(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What**

- Adds a connection close header to the http requests to prevent connections being re-used

**Why**

- We were seeing every other POST /metrics request fail with an EOF error but when we ran with the debugger this didn't happen. After some research it seems like this can happen due to the way the http client tries to re-use connections. Adding this header means we'll close the connection once the request has completed

**Testing**

- Tested this fix out locally