### PR TITLE
FFM-11115 - Update Evaluation logic to be more efficient

### DIFF
--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -26,7 +26,7 @@ const (
 	variationValueAttribute      string = "featureValue"
 	targetAttribute              string = "target"
 	sdkVersionAttribute          string = "SDK_VERSION"
-	SdkVersion                   string = "0.1.19"
+	SdkVersion                   string = "0.1.20"
 	sdkTypeAttribute             string = "SDK_TYPE"
 	sdkType                      string = "server"
 	sdkLanguageAttribute         string = "SDK_LANGUAGE"

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -1799,3 +1799,255 @@ func TestEvaluator_JSONVariation(t *testing.T) {
 		})
 	}
 }
+
+// BENCHMARK
+func BenchmarkEvaluateClause_NilClause(b *testing.B) {
+	evaluator := Evaluator{}
+	var clause *rest.Clause = nil
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_EmptyOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Op:     "",
+		Values: []string{"harness"},
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, nil)
+	}
+}
+
+func BenchmarkEvaluateClause_NilValues(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Values: nil,
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, nil)
+	}
+}
+
+func BenchmarkEvaluateClause_EmptyValues(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Values: []string{},
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, nil)
+	}
+}
+
+func BenchmarkEvaluateClause_WrongOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "greaterthan",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_EmptyAttribute(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "",
+		Op:        "equalOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_MatchOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "matchOperator",
+		Values:    []string{"^harness$"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_MatchOperatorError(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "matchOperator",
+		Values:    []string{"^harness(wings$"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_InOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "inOperator",
+		Values:    []string{"harness", "wings-software"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_InOperatorNotFound(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "inOperator",
+		Values:    []string{"harness1", "wings-software"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_EqualOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "equalOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_EqualSensitiveOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "equalSensitiveOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "Harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_GTOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "gtOperator",
+		Values:    []string{"A"},
+	}
+	target := &Target{
+		Identifier: "B",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_GTOperatorNegative(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "gtOperator",
+		Values:    []string{"B"},
+	}
+	target := &Target{
+		Identifier: "A",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_StartsWithOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "startsWithOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "harness - wings software",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_EndsWithOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "endsWithOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "wings software - harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_ContainsOperator(b *testing.B) {
+	evaluator := Evaluator{}
+	clause := &rest.Clause{
+		Attribute: "identifier",
+		Op:        "containsOperator",
+		Values:    []string{"harness"},
+	}
+	target := &Target{
+		Identifier: "wings harness software",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}
+
+func BenchmarkEvaluateClause_SegmentMatchOperator(b *testing.B) {
+	evaluator := Evaluator{query: testRepo}
+	clause := &rest.Clause{
+		Op:     "segmentMatchOperator",
+		Values: []string{"beta"},
+	}
+	target := &Target{
+		Identifier: "harness",
+	}
+	for i := 0; i < b.N; i++ {
+		evaluator.evaluateClause(clause, target)
+	}
+}

--- a/evaluation/util_test.go
+++ b/evaluation/util_test.go
@@ -2,7 +2,6 @@ package evaluation
 
 import (
 	"reflect"
-	"strconv"
 	"testing"
 
 	"github.com/harness/ff-golang-server-sdk/rest"
@@ -14,119 +13,35 @@ func Test_getAttrValueIsNil(t *testing.T) {
 		attr   string
 	}
 	tests := []struct {
-		name string
-		args args
-		want reflect.Value
+		name    string
+		args    args
+		wantStr string
 	}{
 		{
-			name: "when target is nil should return Value{}",
+			name: "when target is nil should return empty string",
 			args: args{
-				attr: identifier,
+				attr: "identifier",
 			},
-			want: reflect.Value{},
+			wantStr: "",
 		},
 		{
-			name: "wrong attribute should return ValueOf('')",
+			name: "wrong attribute should return empty string",
 			args: args{
 				target: &Target{
-					Identifier: harness,
+					Identifier: "harness",
 					Attributes: &map[string]interface{}{
 						"email": "enver.bisevac@harness.io",
 					},
 				},
 				attr: "no_identifier",
 			},
-			want: reflect.ValueOf(""),
+			wantStr: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getAttrValue(tt.args.target, tt.args.attr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getAttrValue() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_reflectValueToString(t *testing.T) {
-	type args struct {
-		attr interface{}
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "string value",
-			args: args{
-				attr: "email@harness.io",
-			},
-			want: "email@harness.io",
-		},
-		{
-			name: "int value",
-			args: args{
-				attr: 20,
-			},
-			want: "20",
-		},
-		{
-			name: "int64 value",
-			args: args{
-				attr: int64(20),
-			},
-			want: "20",
-		},
-		{
-			name: "float32 value",
-			args: args{
-				attr: float32(20),
-			},
-			want: "20",
-		},
-		{
-			name: "float32 digit value",
-			args: args{
-				attr: float32(20.5678),
-			},
-			want: "20.5678",
-		},
-		{
-			name: "float64 value",
-			args: args{
-				attr: float64(20),
-			},
-			want: "20",
-		},
-		{
-			name: "float64 digit value",
-			args: args{
-				attr: float64(20.5678),
-			},
-			want: "20.5678",
-		},
-		{
-			name: "bool true value",
-			args: args{
-				attr: true,
-			},
-			want: "true",
-		},
-		{
-			name: "bool false value",
-			args: args{
-				attr: false,
-			},
-			want: "false",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			value := reflect.ValueOf(tt.args.attr)
-			got := reflectValueToString(value)
-			if got != tt.want {
-				t.Errorf("valueToString() = %v, want %v", got, tt.want)
+			if got := getAttrValue(tt.args.target, tt.args.attr); got != tt.wantStr {
+				t.Errorf("getAttrValue() = %v, want %v", got, tt.wantStr)
 			}
 		})
 	}
@@ -141,108 +56,86 @@ func Test_getAttrValue(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    reflect.Value
 		wantStr string
 	}{
 		{
 			name: "check identifier",
 			args: args{
 				target: &Target{
-					Identifier: harness,
+					Identifier: "harness",
 				},
-				attr: identifier,
+				attr: "identifier",
 			},
-			want:    reflect.ValueOf(harness),
 			wantStr: "harness",
 		},
 		{
 			name: "check name",
 			args: args{
 				target: &Target{
-					Name: harness,
+					Name: "harness",
 				},
 				attr: "name",
 			},
-			want:    reflect.ValueOf(harness),
 			wantStr: "harness",
 		},
 		{
 			name: "check attributes",
 			args: args{
 				target: &Target{
-					Identifier: identifier,
+					Identifier: "identifier",
 					Attributes: &map[string]interface{}{
 						"email": email,
 					},
 				},
 				attr: "email",
 			},
-			want:    reflect.ValueOf(email),
 			wantStr: email,
 		},
 		{
 			name: "check integer attributes",
 			args: args{
 				target: &Target{
-					Identifier: identifier,
+					Identifier: "identifier",
 					Attributes: &map[string]interface{}{
 						"age": 123,
 					},
 				},
 				attr: "age",
 			},
-			want:    reflect.ValueOf(123),
 			wantStr: "123",
 		},
 		{
 			name: "check int64 attributes",
 			args: args{
 				target: &Target{
-					Identifier: identifier,
+					Identifier: "identifier",
 					Attributes: &map[string]interface{}{
 						"age": int64(123),
 					},
 				},
 				attr: "age",
 			},
-			want:    reflect.ValueOf(int64(123)),
 			wantStr: "123",
 		},
 		{
 			name: "check boolean attributes",
 			args: args{
 				target: &Target{
-					Identifier: identifier,
+					Identifier: "identifier",
 					Attributes: &map[string]interface{}{
 						"active": true,
 					},
 				},
 				attr: "active",
 			},
-			want:    reflect.ValueOf(true),
 			wantStr: "true",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getAttrValue(tt.args.target, tt.args.attr)
-			if !reflect.DeepEqual(got.Interface(), tt.want.Interface()) {
-				t.Errorf("getAttrValue() = %v, want %v", got, tt.want)
-			}
-
-			expObjString := ""
-			//nolint
-			switch got.Kind() {
-			case reflect.Int, reflect.Int64:
-				expObjString = strconv.FormatInt(got.Int(), 10)
-			case reflect.Bool:
-				expObjString = strconv.FormatBool(got.Bool())
-			case reflect.String:
-				expObjString = got.String()
-			}
-
-			if expObjString != tt.wantStr {
-				t.Errorf("getAttrValue() expObjString= %v, want %v", got.String(), tt.wantStr)
+			gotStr := getAttrValue(tt.args.target, tt.args.attr)
+			if gotStr != tt.wantStr {
+				t.Errorf("getAttrValue() = %v, want %v", gotStr, tt.wantStr)
 			}
 		})
 	}


### PR DESCRIPTION
**What**
Updates Go SDK Evaluation logic around clauses
With this we remove the need to use reflect in this logic

**Why**
There are Performance increases to be gained from doing this, which FF-Server would benefit from doing client side evaluations

**Testing**
EvaluateClause tests passed as before so same input is bringing same output
Fixed Tests for the getAttr function to now return a string (as we could remove the reflect to string func)
Benchmark Testing as below

**Evidence**

Refactored Code:


```
/Users/stephenmcconkey/Library/Caches/JetBrains/GoLand2023.2/tmp/GoLand/___gobench_github_com_harness_ff_golang_server_sdk_evaluation.test -test.v -test.paniconexit0 -test.bench . -test.run ^$
goos: darwin
goarch: arm64
pkg: github.com/harness/ff-golang-server-sdk/evaluation
BenchmarkEvaluateClause_NilClause
BenchmarkEvaluateClause_NilClause-10                 	539388770	         2.118 ns/op
BenchmarkEvaluateClause_EmptyOperator
BenchmarkEvaluateClause_EmptyOperator-10             	573256963	         2.147 ns/op
BenchmarkEvaluateClause_NilValues
BenchmarkEvaluateClause_NilValues-10                 	571950588	         2.085 ns/op
BenchmarkEvaluateClause_EmptyValues
BenchmarkEvaluateClause_EmptyValues-10               	577386420	         2.076 ns/op
BenchmarkEvaluateClause_WrongOperator
BenchmarkEvaluateClause_WrongOperator-10             	95167285	        12.60 ns/op
BenchmarkEvaluateClause_EmptyAttribute
BenchmarkEvaluateClause_EmptyAttribute-10            	237732388	         5.073 ns/op
BenchmarkEvaluateClause_MatchOperator
BenchmarkEvaluateClause_MatchOperator-10             	93533827	        12.94 ns/op
BenchmarkEvaluateClause_MatchOperatorError
BenchmarkEvaluateClause_MatchOperatorError-10        	90778142	        12.88 ns/op
BenchmarkEvaluateClause_InOperator
BenchmarkEvaluateClause_InOperator-10                	96405542	        12.55 ns/op
BenchmarkEvaluateClause_InOperatorNotFound
BenchmarkEvaluateClause_InOperatorNotFound-10        	94263358	        12.75 ns/op
BenchmarkEvaluateClause_EqualOperator
BenchmarkEvaluateClause_EqualOperator-10             	93184884	        12.94 ns/op
BenchmarkEvaluateClause_EqualSensitiveOperator
BenchmarkEvaluateClause_EqualSensitiveOperator-10    	93156548	        12.93 ns/op
BenchmarkEvaluateClause_GTOperator
BenchmarkEvaluateClause_GTOperator-10                	95136472	        12.60 ns/op
BenchmarkEvaluateClause_GTOperatorNegative
BenchmarkEvaluateClause_GTOperatorNegative-10        	95507493	        12.60 ns/op
BenchmarkEvaluateClause_StartsWithOperator
BenchmarkEvaluateClause_StartsWithOperator-10        	93169813	        12.89 ns/op
BenchmarkEvaluateClause_EndsWithOperator
BenchmarkEvaluateClause_EndsWithOperator-10          	94167802	        12.93 ns/op
BenchmarkEvaluateClause_ContainsOperator
BenchmarkEvaluateClause_ContainsOperator-10          	92775730	        12.91 ns/op
BenchmarkEvaluateClause_SegmentMatchOperator
BenchmarkEvaluateClause_SegmentMatchOperator-10      	238270216	         5.027 ns/op
PASS
```


Old Code:

```
/Users/stephenmcconkey/Library/Caches/JetBrains/GoLand2023.2/tmp/GoLand/___gobench_github_com_harness_ff_golang_server_sdk_evaluation.test -test.v -test.paniconexit0 -test.bench . -test.run ^$
goos: darwin
goarch: arm64
pkg: github.com/harness/ff-golang-server-sdk/evaluation
BenchmarkEvaluateClause_NilClause
BenchmarkEvaluateClause_NilClause-10                 	549836156	         2.072 ns/op
BenchmarkEvaluateClause_EmptyOperator
BenchmarkEvaluateClause_EmptyOperator-10             	578069950	         2.067 ns/op
BenchmarkEvaluateClause_NilValues
BenchmarkEvaluateClause_NilValues-10                 	577941537	         2.088 ns/op
BenchmarkEvaluateClause_EmptyValues
BenchmarkEvaluateClause_EmptyValues-10               	573185658	         2.101 ns/op
BenchmarkEvaluateClause_WrongOperator
BenchmarkEvaluateClause_WrongOperator-10             	32965221	        35.93 ns/op
BenchmarkEvaluateClause_EmptyAttribute
BenchmarkEvaluateClause_EmptyAttribute-10            	85589721	        14.03 ns/op
BenchmarkEvaluateClause_MatchOperator
BenchmarkEvaluateClause_MatchOperator-10             	33532392	        35.96 ns/op
BenchmarkEvaluateClause_MatchOperatorError
BenchmarkEvaluateClause_MatchOperatorError-10        	32738320	        36.24 ns/op
BenchmarkEvaluateClause_InOperator
BenchmarkEvaluateClause_InOperator-10                	32440322	        36.04 ns/op
BenchmarkEvaluateClause_InOperatorNotFound
BenchmarkEvaluateClause_InOperatorNotFound-10        	33301380	        36.36 ns/op
BenchmarkEvaluateClause_EqualOperator
BenchmarkEvaluateClause_EqualOperator-10             	33263110	        36.21 ns/op
BenchmarkEvaluateClause_EqualSensitiveOperator
BenchmarkEvaluateClause_EqualSensitiveOperator-10    	33258616	        36.45 ns/op
BenchmarkEvaluateClause_GTOperator
BenchmarkEvaluateClause_GTOperator-10                	32981869	        36.60 ns/op
BenchmarkEvaluateClause_GTOperatorNegative
BenchmarkEvaluateClause_GTOperatorNegative-10        	33067188	        35.88 ns/op
BenchmarkEvaluateClause_StartsWithOperator
BenchmarkEvaluateClause_StartsWithOperator-10        	33081355	        36.06 ns/op
BenchmarkEvaluateClause_EndsWithOperator
BenchmarkEvaluateClause_EndsWithOperator-10          	33321454	        36.29 ns/op
BenchmarkEvaluateClause_ContainsOperator
BenchmarkEvaluateClause_ContainsOperator-10          	33318834	        36.32 ns/op
BenchmarkEvaluateClause_SegmentMatchOperator
BenchmarkEvaluateClause_SegmentMatchOperator-10      	84904160	        14.06 ns/op
PASS
```


**Summary of results is:**

- NilClause, EmptyOperator, NilValues, EmptyValues:  Performance in these categories is very similar between the new and old code. The new code shows a very slight increase in execution time per operation, indicating a negligible performance impact.
- WrongOperator, MatchOperator, MatchOperatorError, InOperator, InOperatorNotFound, EqualOperator, EqualSensitiveOperator, GTOperator, GTOperatorNegative, StartsWithOperator, EndsWithOperator, ContainsOperator: Significant performance improvement in the refactored code. The execution time per operation has decreased dramatically from around 35-36 ns/op to approximately 12-13 ns/op, indicating that the new code is nearly 3 times faster for these operations.
- EmptyAttribute, SegmentMatchOperator: also show improvement in the refactored code. Execution time has reduced from around 14 ns/op to about 5 ns/op, more than halving the time taken per operation, which is a considerable improvement.