### PR TITLE
FFM-11164 Evaluate `AND` rules

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -179,16 +179,16 @@ func (e Evaluator) evaluateRules(servingRules []rest.ServingRule, target *Target
 // evaluateGroupRulesV2 evaluates the group rules using AND logic instead of OR.
 func (e Evaluator) evaluateGroupRulesV2(rules []rest.Clause, target *Target) bool {
 	if len(rules) == 0 {
-		e.logger.Debugf("'AND' rules are empty, returning false")
+		e.logger.Debugf("No 'AND' rules provided, returning false")
 		return false
 	}
 	for _, rule := range rules {
 		if !e.evaluateClause(&rule, target) {
-			e.logger.Debugf("'AND' rule did not match, returning false: %+v", rule)
+			e.logger.Debugf("'AND' rule did not match: %+v, returning false", rule)
 			return false
 		}
 	}
-	e.logger.Debugf("All 'AND' rules matched: %+v", rules)
+	e.logger.Debugf("All 'AND' rules successfully matched for target: %+v", target)
 	return true
 }
 

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -284,10 +284,10 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 			sort.SliceStable(v2Rules, func(i, j int) bool {
 				return v2Rules[i].Priority < v2Rules[j].Priority
 			})
-			if included, clause := e.evaluateGroupRules(v2Rules, target); included {
-				e.logger.Debugf(
-					"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
-				return true
+			for _, v2rule := range v2Rules {
+				if e.evaluateGroupRulesV2(v2rule.Clauses, target) {
+					return true
+				}
 			}
 			return false
 		}

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -286,6 +286,8 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 			})
 			for _, v2rule := range v2Rules {
 				if e.evaluateGroupRulesV2(v2rule.Clauses, target) {
+					e.logger.Debugf(
+						"Target [%s] included in group [%s] via rules %+v", target.Name, segment.Name, v2Rules)
 					return true
 				}
 			}

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -289,6 +289,8 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 					e.logger.Debugf(
 						"Target [%s] included in group [%s] via rules %+v", target.Name, segment.Name, v2Rules)
 					return true
+				} else {
+					return false
 				}
 			}
 			return false

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -289,8 +289,6 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 					e.logger.Debugf(
 						"Target [%s] included in group [%s] via rules %+v", target.Name, segment.Name, v2Rules)
 					return true
-				} else {
-					return false
 				}
 			}
 			return false

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -176,6 +176,22 @@ func (e Evaluator) evaluateRules(servingRules []rest.ServingRule, target *Target
 	return ""
 }
 
+// evaluateGroupRulesV2 evaluates the group rules using AND logic instead of OR.
+func (e Evaluator) evaluateGroupRulesV2(rules []rest.Clause, target *Target) bool {
+	if len(rules) == 0 {
+		e.logger.Debugf("'AND' rules are empty, returning false")
+		return false
+	}
+	for _, rule := range rules {
+		if !e.evaluateClause(&rule, target) {
+			e.logger.Debugf("'AND' rule did not match, returning false: %+v", rule)
+			return false
+		}
+	}
+	e.logger.Debugf("All 'AND' rules matched: %+v", rules)
+	return true
+}
+
 // evaluateGroupRules evaluates the groups rules.  Note Group rule are represented by a rest.Clause, instead
 // of a rest.Rule.   Unlike feature clauses which are AND'd, in a case of  a group these must be OR'd.
 func (e Evaluator) evaluateGroupRules(rules []rest.Clause, target *Target) (bool, rest.Clause) {

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -285,23 +285,11 @@ var (
 								Op:        endsWithOperator,
 								Values:    []string{"@harness.io"},
 							},
-						},
-					},
-					{
-						Priority: 2,
-						RuleId:   "rule2",
-						Clauses: []rest.Clause{
 							{
 								Attribute: "role",
 								Op:        equalOperator,
 								Values:    []string{"sre"},
 							},
-						},
-					},
-					{
-						Priority: 3,
-						RuleId:   "rule3",
-						Clauses: []rest.Clause{
 							{
 								Attribute: "active",
 								Op:        equalOperator,
@@ -1343,7 +1331,7 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 					Attributes: &map[string]interface{}{
 						"email":  "hello@harness.io",
 						"role":   "sre",
-						"active": false,
+						"active": true,
 					},
 				},
 			},

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -11,25 +11,26 @@ import (
 )
 
 const (
-	identifier        = "identifier"
-	harness           = "harness"
-	beta              = "beta"
-	alpha             = "alpha"
-	v2GroupRules      = "v2GroupRules"
-	excluded          = "excluded"
-	offVariation      = "false"
-	simple            = "simple"
-	simpleWithPrereq  = "simplePrereq"
-	notValidFlag      = "notValidFlag"
-	theme             = "theme"
-	size              = "size"
-	weight            = "weight"
-	org               = "org"
-	invalidInt        = "invalidInt"
-	invalidNumber     = "invalidNumber"
-	invalidJSON       = "invalidJSON"
-	prereqNotFound    = "prereqNotFound"
-	prereqVarNotFound = "prereqVarNotFound"
+	identifier            = "identifier"
+	harness               = "harness"
+	beta                  = "beta"
+	alpha                 = "alpha"
+	v2GroupRulesAllAnd    = "v2GroupRulesAllAnd"
+	v2GroupRulesANDWithOr = "v2GroupRulesAndWithOr"
+	excluded              = "excluded"
+	offVariation          = "false"
+	simple                = "simple"
+	simpleWithPrereq      = "simplePrereq"
+	notValidFlag          = "notValidFlag"
+	theme                 = "theme"
+	size                  = "size"
+	weight                = "weight"
+	org                   = "org"
+	invalidInt            = "invalidInt"
+	invalidNumber         = "invalidNumber"
+	invalidJSON           = "invalidJSON"
+	prereqNotFound        = "prereqNotFound"
+	prereqVarNotFound     = "prereqVarNotFound"
 )
 
 var (
@@ -273,8 +274,34 @@ var (
 					},
 				},
 			},
-			v2GroupRules: {
-				Identifier: v2GroupRules,
+			v2GroupRulesAllAnd: {
+				Identifier: v2GroupRulesAllAnd,
+				ServingRules: &[]rest.GroupServingRule{
+					{
+						Priority: 1,
+						RuleId:   "rule1",
+						Clauses: []rest.Clause{
+							{
+								Attribute: "email",
+								Op:        endsWithOperator,
+								Values:    []string{"@harness.io"},
+							},
+							{
+								Attribute: "role",
+								Op:        equalOperator,
+								Values:    []string{"sre"},
+							},
+							{
+								Attribute: "active",
+								Op:        equalOperator,
+								Values:    []string{"true"},
+							},
+						},
+					},
+				},
+			},
+			v2GroupRulesANDWithOr: {
+				Identifier: v2GroupRulesAllAnd,
 				ServingRules: &[]rest.GroupServingRule{
 					{
 						Priority: 1,
@@ -1325,7 +1352,7 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 				query: testRepo,
 			},
 			args: args{
-				segmentList: []string{v2GroupRules},
+				segmentList: []string{v2GroupRulesAllAnd},
 				target: &Target{
 					Identifier: "no_identifier",
 					Attributes: &map[string]interface{}{

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -15,6 +15,7 @@ const (
 	harness           = "harness"
 	beta              = "beta"
 	alpha             = "alpha"
+	v2GroupRules      = "v2GroupRules"
 	excluded          = "excluded"
 	offVariation      = "false"
 	simple            = "simple"
@@ -269,6 +270,44 @@ var (
 						Attribute: identifier,
 						Op:        equalOperator,
 						Values:    []string{harness},
+					},
+				},
+			},
+			v2GroupRules: {
+				Identifier: v2GroupRules,
+				ServingRules: &[]rest.GroupServingRule{
+					{
+						Priority: 1,
+						RuleId:   "rule1",
+						Clauses: []rest.Clause{
+							{
+								Attribute: "email",
+								Op:        endsWithOperator,
+								Values:    []string{"@harness.io"},
+							},
+						},
+					},
+					{
+						Priority: 2,
+						RuleId:   "rule2",
+						Clauses: []rest.Clause{
+							{
+								Attribute: "role",
+								Op:        equalOperator,
+								Values:    []string{"sre"},
+							},
+						},
+					},
+					{
+						Priority: 3,
+						RuleId:   "rule3",
+						Clauses: []rest.Clause{
+							{
+								Attribute: "active",
+								Op:        equalOperator,
+								Values:    []string{"true"},
+							},
+						},
 					},
 				},
 			},
@@ -1291,6 +1330,24 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			name: "evaluate rule in v2 group rules should return true",
+			fields: fields{
+				query: testRepo,
+			},
+			args: args{
+				segmentList: []string{v2GroupRules},
+				target: &Target{
+					Identifier: "no_identifier",
+					Attributes: &map[string]interface{}{
+						"email":  "hello@harness.io",
+						"role":   "sre",
+						"active": false,
+					},
+				},
+			},
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/evaluation/evaluator_test.go
+++ b/evaluation/evaluator_test.go
@@ -312,6 +312,12 @@ var (
 								Op:        endsWithOperator,
 								Values:    []string{"@harness.io"},
 							},
+						},
+					},
+					{
+						Priority: 2,
+						RuleId:   "rule2",
+						Clauses: []rest.Clause{
 							{
 								Attribute: "role",
 								Op:        equalOperator,
@@ -1347,7 +1353,7 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "evaluate rule in v2 group rules should return true",
+			name: "one AND rule",
 			fields: fields{
 				query: testRepo,
 			},
@@ -1357,6 +1363,24 @@ func TestEvaluator_isTargetIncludedOrExcludedInSegment(t *testing.T) {
 					Identifier: "no_identifier",
 					Attributes: &map[string]interface{}{
 						"email":  "hello@harness.io",
+						"role":   "sre",
+						"active": true,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "one AND with one OR",
+			fields: fields{
+				query: testRepo,
+			},
+			args: args{
+				segmentList: []string{v2GroupRulesANDWithOr},
+				target: &Target{
+					Identifier: "no_identifier",
+					Attributes: &map[string]interface{}{
+						"email":  "hello@contractor.io",
 						"role":   "sre",
 						"active": true,
 					},


### PR DESCRIPTION
# What
Supports new `AND` rules:

- `GroupServingRule` is the new rule type sent by the backend. They are:
    -  Evaluated by `Priority` 
    - `GroupServingRule.Clauses` are AND'ed
    -  Additional `GroupServingRule` with lesser priority are OR'd (with their clauses AND'ed). 
- If there are no `GroupServingRule` to evaluate, then we fall back to the legacy `Rule` which is OR`d. 

# Testing
- Unit tests 