### PR TITLE
FFM-11194 `AND/OR`: Continue to next group rule

### DIFF
--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -291,20 +291,18 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 					return true
 				}
 			}
-			return false
-		}
-
-		// Fall back to legacy `Rules`
-		if segment.Rules != nil && len(*segment.Rules) > 0 {
-			// Should Target be included via segment rules
-			legacyRules := *segment.Rules
-			if included, clause := e.evaluateGroupRules(legacyRules, target); included {
-				e.logger.Debugf(
-					"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
-				return true
+		} else {
+			// Fall back to legacy `Rules`
+			if segment.Rules != nil && len(*segment.Rules) > 0 {
+				// Should Target be included via segment rules
+				legacyRules := *segment.Rules
+				if included, clause := e.evaluateGroupRules(legacyRules, target); included {
+					e.logger.Debugf(
+						"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
+					return true
+				}
 			}
 		}
-
 	}
 	return false
 }

--- a/evaluation/evaluator.go
+++ b/evaluation/evaluator.go
@@ -291,18 +291,20 @@ func (e Evaluator) isTargetIncludedOrExcludedInSegment(segmentList []string, tar
 					return true
 				}
 			}
-		} else {
-			// Fall back to legacy `Rules`
-			if segment.Rules != nil && len(*segment.Rules) > 0 {
-				// Should Target be included via segment rules
-				legacyRules := *segment.Rules
-				if included, clause := e.evaluateGroupRules(legacyRules, target); included {
-					e.logger.Debugf(
-						"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
-					return true
-				}
+			continue
+		}
+
+		// Fall back to legacy `Rules`
+		if segment.Rules != nil && len(*segment.Rules) > 0 {
+			// Should Target be included via segment rules
+			legacyRules := *segment.Rules
+			if included, clause := e.evaluateGroupRules(legacyRules, target); included {
+				e.logger.Debugf(
+					"Target [%s] included in group [%s] via rule %+v", target.Name, segment.Name, clause)
+				return true
 			}
 		}
+
 	}
 	return false
 }


### PR DESCRIPTION
# What
In the new `AND/OR` logic, if a group didn't match then the SDK would return `false` instead of iterating to the next group and checking it.  This has been fixed by using `continue` instead of `return false`

# Testing
Migrated TestGrid scenarios

Before fix:
![Screenshot 2024-04-19 at 17 43 49](https://github.com/harness/ff-golang-server-sdk/assets/23323369/fb17c31a-53b9-4d04-8c47-d3790448374e)


After fix:
![Screenshot 2024-04-19 at 18 06 44](https://github.com/harness/ff-golang-server-sdk/assets/23323369/2006f4fd-907e-45e0-9c28-bfbed5cadb03)


