### PR TITLE
FFM-10311 Build TestGrid image on PR

### DIFF
--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -107,35 +107,58 @@ pipeline:
                             spec:
                               branch: main
                         description: Get the source code for ff-sdk-testgrid so we can build the go test grid container
-                    - step:
-                        type: GitClone
-                        name: Copy SDK code
-                        identifier: Copy_SDK_code
-                        spec:
-                          connectorRef: ffsdks
-                          repoName: ff-golang-server-sdk
-                          cloneDirectory: ff-sdk-testgrid/go/ff-golang-server-sdk
-                          build:
-                            type: tag
-                            spec:
-                              tag: <+codebase.tag>
-                        description: Copy ff-golang-server-sdk code to the docker build context
-                    - step:
-                        type: BuildAndPushGCR
-                        name: Build And Push testgrid image to GCR
-                        identifier: Build_And_Push_testgrid_image_to_GCR
-                        spec:
-                          connectorRef: platform205701
-                          host: us.gcr.io
-                          projectID: platform-205701
-                          imageName: ff-testgrid-go
-                          tags:
-                            - <+codebase.tag>
-                          dockerfile: ff-sdk-testgrid/go/Dockerfile
-                          context: ff-sdk-testgrid/go
-                          buildArgs:
-                            SDK_VERSION: <+codebase.tag>
-                            BUILD_MODE: local
+                    - parallel:
+                        - stepGroup:
+                            name: Release
+                            identifier: Release
+                            steps:
+                              - step:
+                                  type: GitClone
+                                  name: Copy SDK code - Release
+                                  identifier: Copy_SDK_code
+                                  spec:
+                                    connectorRef: ffsdks
+                                    repoName: ff-golang-server-sdk
+                                    cloneDirectory: ff-sdk-testgrid/go/ff-golang-server-sdk
+                                    build:
+                                      type: tag
+                                      spec:
+                                        tag: <+codebase.tag>
+                                  description: Copy ff-golang-server-sdk code to the docker build context
+                              - step:
+                                  type: BuildAndPushGCR
+                                  name: Build And Push testgrid image to GCR
+                                  identifier: Build_And_Push_testgrid_image_to_GCR
+                                  spec:
+                                    connectorRef: platform205701
+                                    host: us.gcr.io
+                                    projectID: platform-205701
+                                    imageName: ff-testgrid-go
+                                    tags:
+                                      - <+codebase.tag>
+                                    dockerfile: ff-sdk-testgrid/go/Dockerfile
+                                    context: ff-sdk-testgrid/go
+                                    buildArgs:
+                                      SDK_VERSION: <+codebase.tag>
+                                      BUILD_MODE: local
+                        - stepGroup:
+                            name: Pull Request
+                            identifier: Pull_Request
+                            steps:
+                              - step:
+                                  type: GitClone
+                                  name: Copy SDK Code
+                                  identifier: Copy_SDK_Code
+                                  spec:
+                                    connectorRef: ffsdks
+                                    repoName: ff-golang-server-sdk
+                                    cloneDirectory: ff-sdk-testgrid/go/ff-golang-server-sdk
+                                    build:
+                                      type: branch
+                                      spec:
+                                        branch: <+trigger.sourceBranch>
+                                  when:
+                                    stageStatus: Success
                   when:
                     stageStatus: Success
                     condition: "!empty(<+codebase.tag>)"

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -178,6 +178,10 @@ pipeline:
                                     buildArgs:
                                       SDK_VERSION: v0.1.24
                                       BUILD_MODE: local
+                                    resources:
+                                      limits:
+                                        memory: 10G
+                                        cpu: "10"
                             when:
                               stageStatus: Success
                               condition: <+stage.variables.pull_request>

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -180,7 +180,7 @@ pipeline:
                                       BUILD_MODE: local
                             when:
                               stageStatus: Success
-                              condition: <+codebase.build.type>=="PR"
+                              condition: <+stage.variables.pull_request>
                   when:
                     stageStatus: Success
               - step:

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -91,7 +91,7 @@ pipeline:
 
                            echo "View Results Here: https://sonar.harness.io/dashboard?id=harness_ff-golang-server-sdk_AYSkVwnLWr37sP7QAgtQ"
               - stepGroup:
-                  name: Testgrid image - Release
+                  name: Testgrid image
                   identifier: Testgrid_image
                   steps:
                     - step:

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -282,6 +282,17 @@ pipeline:
               spec:
                 connectorRef: DockerHub
                 image: docker:dind
+        variables:
+          - name: pull_request
+            type: String
+            description: ""
+            required: false
+            value: <+input>.allowedValues(true,false)
+          - name: release
+            type: String
+            description: ""
+            required: false
+            value: <+input>.allowedValues(true,false)
     - stage:
         name: Publish Release Notes
         identifier: Publish_Release_Notes

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -141,6 +141,9 @@ pipeline:
                                     buildArgs:
                                       SDK_VERSION: <+codebase.tag>
                                       BUILD_MODE: local
+                            when:
+                              stageStatus: Success
+                              condition: "!empty(<+codebase.tag>)"
                         - stepGroup:
                             name: Pull Request
                             identifier: Pull_Request
@@ -175,9 +178,11 @@ pipeline:
                                     buildArgs:
                                       SDK_VERSION: <+trigger.commitSha>
                                       BUILD_MODE: local
+                            when:
+                              stageStatus: Success
+                              condition: <+pipeline.variables.pull_request>
                   when:
                     stageStatus: Success
-                    condition: "!empty(<+codebase.tag>)"
               - step:
                   type: Run
                   name: CVE scan

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -159,6 +159,22 @@ pipeline:
                                         branch: <+trigger.sourceBranch>
                                   when:
                                     stageStatus: Success
+                              - step:
+                                  type: BuildAndPushGCR
+                                  name: Build And Push testgrid image
+                                  identifier: Build_And_Push_testgrid_image
+                                  spec:
+                                    connectorRef: platform205701
+                                    host: us.gcr.io
+                                    projectID: platform-205701
+                                    imageName: ff-testgrid-go
+                                    tags:
+                                      - <+trigger.commitSha>
+                                    dockerfile: ff-sdk-testgrid/go/Dockerfile
+                                    context: ff-sdk-testgrid/go
+                                    buildArgs:
+                                      SDK_VERSION: <+trigger.commitSha>
+                                      BUILD_MODE: local
                   when:
                     stageStatus: Success
                     condition: "!empty(<+codebase.tag>)"

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -176,7 +176,7 @@ pipeline:
                                     dockerfile: ff-sdk-testgrid/go/Dockerfile
                                     context: ff-sdk-testgrid/go
                                     buildArgs:
-                                      SDK_VERSION: <+trigger.commitSha>
+                                      SDK_VERSION: v0.1.24
                                       BUILD_MODE: local
                             when:
                               stageStatus: Success

--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -180,7 +180,7 @@ pipeline:
                                       BUILD_MODE: local
                             when:
                               stageStatus: Success
-                              condition: <+pipeline.variables.pull_request>
+                              condition: <+codebase.build.type>=="PR"
                   when:
                     stageStatus: Success
               - step:

--- a/.harness/pull_request_input_set.yaml
+++ b/.harness/pull_request_input_set.yaml
@@ -1,5 +1,6 @@
 inputSet:
   name: pull_request_input_set
+  tags: {}
   identifier: pull_request_input_set
   orgIdentifier: Feature_Flag
   projectIdentifier: FFPipelines
@@ -14,13 +15,23 @@ inputSet:
               branch: <+trigger.branch>
     stages:
       - stage:
+          identifier: Build
+          type: CI
+          variables:
+            - name: pull_request
+              type: String
+              value: "true"
+            - name: release
+              type: String
+              value: "false"
+      - stage:
           identifier: Publish_Release_Notes
           type: Approval
           variables:
             - name: release
               type: String
+              default: "false"
               value: "false"
             - name: pull_request
               type: String
               value: "true"
-  object Object: pipeline.properties.ci.codebase


### PR DESCRIPTION
# What
Builds and pushes a TestGrid Docker image for each commit pushed to an open Pull Request

# Why
So we can pull the image for easy testing of changes in a local ff-sever test environment. Building the image locally can involve toil due to image architecture constraints, and other issues around using unpublished versions of the SDK.

# Testing 
Image is tagged with commit SHA and pushed to GCR correctly.