### PR TITLE
FFM-11660 Add configurable limit to the seen targets map

### DIFF
--- a/.harness/ffgolangserversdk.yaml
+++ b/.harness/ffgolangserversdk.yaml
@@ -176,7 +176,7 @@ pipeline:
                                     dockerfile: ff-sdk-testgrid/go/Dockerfile
                                     context: ff-sdk-testgrid/go
                                     buildArgs:
-                                      SDK_VERSION: v0.1.24
+                                      SDK_VERSION: v0.1.25
                                       BUILD_MODE: local
                                     resources:
                                       limits:

--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -49,7 +49,6 @@ type SafeAnalyticsCache[K comparable, V any] interface {
 // SafeSeenTargetsCache extends SafeAnalyticsCache and adds behavior specific to seen targets
 type SafeSeenTargetsCache[K comparable, V any] interface {
 	SafeAnalyticsCache[K, V]
-	setWithLimit(key K, value V)
 	isLimitExceeded() bool
 }
 
@@ -170,7 +169,7 @@ func (as *AnalyticsService) listener() {
 		}
 
 		// Update seen targets
-		as.seenTargets.setWithLimit(ad.target.Identifier, true)
+		as.seenTargets.set(ad.target.Identifier, true)
 
 		// Update target metrics
 		if as.targetAnalytics.size() < maxTargetEntries {

--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -156,16 +156,12 @@ func (as *AnalyticsService) listener() {
 		}
 
 		// Check if target has been seen
-		_, seen := as.seenTargets.get(ad.target.Identifier)
-
-		if seen {
+		if _, seen := as.seenTargets.get(ad.target.Identifier); seen {
 			continue
 		}
 
 		// Check if seen targets limit has been hit
-		limitExceeded := as.seenTargets.isLimitExceeded()
-
-		if limitExceeded {
+		if as.seenTargets.isLimitExceeded() {
 			continue
 		}
 

--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -334,7 +334,7 @@ func (as *AnalyticsService) startSeenTargetsClearingSchedule(ctx context.Context
 	for {
 		select {
 		case <-ticker.C:
-			as.logger.Infof("Clearing seen targets")
+			as.logger.Debugf("Clearing seen targets")
 			as.seenTargets.clear()
 
 		case <-ctx.Done():

--- a/analyticsservice/analytics_test.go
+++ b/analyticsservice/analytics_test.go
@@ -120,7 +120,7 @@ func TestListenerHandlesEventsCorrectly(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			service := NewAnalyticsService(1*time.Minute, noOpLogger)
+			service := NewAnalyticsService(1*time.Minute, noOpLogger, 10, time.Hour)
 			defer close(service.analyticsChan)
 
 			// Start the listener in a goroutine

--- a/analyticsservice/safe_maps_test.go
+++ b/analyticsservice/safe_maps_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 )
@@ -85,7 +84,7 @@ func TestSafeTargetAnalytics(t *testing.T) {
 func TestSafeSeenTargets(t *testing.T) {
 	// Initialize with a small maxSize for testing
 	maxSize := 3
-	s := newSafeSeenTargets(maxSize, 0).(SafeSeenTargetsCache[string, bool])
+	s := newSafeSeenTargets(maxSize).(SafeSeenTargetsCache[string, bool])
 
 	testData := map[string]bool{
 		"target1":  true,
@@ -135,7 +134,7 @@ func TestSafeSeenTargets(t *testing.T) {
 		concurrencyLevel := 100
 
 		// Re-initialize the map for concurrency testing
-		s = newSafeSeenTargets(100, 0).(SafeSeenTargetsCache[string, bool])
+		s = newSafeSeenTargets(100).(SafeSeenTargetsCache[string, bool])
 
 		// Concurrently set keys
 		for i := 0; i < concurrencyLevel; i++ {
@@ -173,32 +172,5 @@ func TestSafeSeenTargets(t *testing.T) {
 			t.Errorf("Map size should be 0 after clearing, got %d", s.size())
 		}
 	})
-
-	// Add test for clearing based on interval
-	t.Run("IntervalClearingTest", func(t *testing.T) {
-		// Re-initialize the map with a clearing interval
-		s = newSafeSeenTargets(10, 100*time.Millisecond)
-
-		for key, value := range testData {
-			s.set(key, value)
-		}
-
-		// Ensure the map has items initially
-		if s.size() != len(testData) {
-			t.Errorf("Expected map size to be %d, got %d", len(testData), s.size())
-		}
-
-		// Wait for the clearing to clear the map
-		time.Sleep(300 * time.Millisecond)
-
-		// Ensure the map is cleared after the interval
-		if s.size() != 0 {
-			t.Errorf("Expected map size to be 0 after clearing interval, got %d", s.size())
-		}
-
-		// Ensure the limitExceeded flag is reset
-		if s.isLimitExceeded() {
-			t.Errorf("Expected limitExceeded to be reset after clearing")
-		}
-	})
+	
 }

--- a/analyticsservice/safe_maps_test.go
+++ b/analyticsservice/safe_maps_test.go
@@ -102,7 +102,7 @@ func TestSafeSeenTargets(t *testing.T) {
 	}
 
 	// Add one more item to exceed the limit
-	s.setWithLimit("target4", true)
+	s.set("target4", true)
 
 	// Ensure limitExceeded is true after exceeding the limit
 	if !s.isLimitExceeded() {
@@ -110,7 +110,7 @@ func TestSafeSeenTargets(t *testing.T) {
 	}
 
 	// Ensure that new items are not added once the limit is exceeded
-	s.setWithLimit("target5", true)
+	s.set("target5", true)
 	if _, exists := s.get("target5"); exists {
 		t.Errorf("target5 should not have been added as the limit was exceeded")
 	}
@@ -123,7 +123,7 @@ func TestSafeSeenTargets(t *testing.T) {
 	}
 
 	// Add items again after clearing
-	s.setWithLimit("target6", true)
+	s.set("target6", true)
 	if _, exists := s.get("target6"); !exists {
 		t.Errorf("target6 should have been added after clearing the map")
 	}
@@ -142,7 +142,7 @@ func TestSafeSeenTargets(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				key := "target" + fmt.Sprint(i)
-				s.setWithLimit(key, true)
+				s.set(key, true)
 			}(i)
 		}
 
@@ -172,5 +172,5 @@ func TestSafeSeenTargets(t *testing.T) {
 			t.Errorf("Map size should be 0 after clearing, got %d", s.size())
 		}
 	})
-	
+
 }

--- a/analyticsservice/safe_maps_test.go
+++ b/analyticsservice/safe_maps_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 )
@@ -170,6 +171,34 @@ func TestSafeSeenTargets(t *testing.T) {
 		// Ensure the map is cleared after the concurrency operations
 		if s.size() > 0 {
 			t.Errorf("Map size should be 0 after clearing, got %d", s.size())
+		}
+	})
+
+	// Add test for clearing based on interval
+	t.Run("IntervalClearingTest", func(t *testing.T) {
+		// Re-initialize the map with a clearing interval
+		s = newSafeSeenTargets(10, 100*time.Millisecond)
+
+		for key, value := range testData {
+			s.set(key, value)
+		}
+
+		// Ensure the map has items initially
+		if s.size() != len(testData) {
+			t.Errorf("Expected map size to be %d, got %d", len(testData), s.size())
+		}
+
+		// Wait for the clearing to clear the map
+		time.Sleep(300 * time.Millisecond)
+
+		// Ensure the map is cleared after the interval
+		if s.size() != 0 {
+			t.Errorf("Expected map size to be 0 after clearing interval, got %d", s.size())
+		}
+
+		// Ensure the limitExceeded flag is reset
+		if s.isLimitExceeded() {
+			t.Errorf("Expected limitExceeded to be reset after clearing")
 		}
 	})
 }

--- a/analyticsservice/safe_maps_test.go
+++ b/analyticsservice/safe_maps_test.go
@@ -1,6 +1,7 @@
 package analyticsservice
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -81,13 +82,94 @@ func TestSafeTargetAnalytics(t *testing.T) {
 }
 
 func TestSafeSeenTargets(t *testing.T) {
-	s := newSafeSeenTargets()
+	// Initialize with a small maxSize for testing
+	maxSize := 3
+	s := newSafeSeenTargets(maxSize, 0).(SafeSeenTargetsCache[string, bool])
+
 	testData := map[string]bool{
 		"target1":  true,
 		"target21": true,
 		"target3":  true,
-		"target4":  true,
 	}
 
-	testMapOperations[string, bool](t, s, testData)
+	// Insert items and ensure limit is not exceeded
+	for key, value := range testData {
+		s.set(key, value)
+	}
+
+	if s.isLimitExceeded() {
+		t.Errorf("Limit should not have been exceeded yet")
+	}
+
+	// Add one more item to exceed the limit
+	s.setWithLimit("target4", true)
+
+	// Ensure limitExceeded is true after exceeding the limit
+	if !s.isLimitExceeded() {
+		t.Errorf("Limit should be exceeded after adding target4")
+	}
+
+	// Ensure that new items are not added once the limit is exceeded
+	s.setWithLimit("target5", true)
+	if _, exists := s.get("target5"); exists {
+		t.Errorf("target5 should not have been added as the limit was exceeded")
+	}
+
+	// Clear the map and ensure limit is reset
+	s.clear()
+
+	if s.isLimitExceeded() {
+		t.Errorf("Limit should have been reset after clearing the map")
+	}
+
+	// Add items again after clearing
+	s.setWithLimit("target6", true)
+	if _, exists := s.get("target6"); !exists {
+		t.Errorf("target6 should have been added after clearing the map")
+	}
+
+	// Concurrency test
+	t.Run("ConcurrencyTest", func(t *testing.T) {
+		var wg sync.WaitGroup
+		concurrencyLevel := 100
+
+		// Re-initialize the map for concurrency testing
+		s = newSafeSeenTargets(100, 0).(SafeSeenTargetsCache[string, bool])
+
+		// Concurrently set keys
+		for i := 0; i < concurrencyLevel; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := "target" + fmt.Sprint(i)
+				s.setWithLimit(key, true)
+			}(i)
+		}
+
+		// Concurrently get keys
+		for i := 0; i < concurrencyLevel; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := "target" + fmt.Sprint(i)
+				s.get(key)
+			}(i)
+		}
+
+		// Concurrently clear the map
+		for i := 0; i < concurrencyLevel/2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				s.clear()
+			}()
+		}
+
+		wg.Wait()
+
+		// Ensure the map is cleared after the concurrency operations
+		if s.size() > 0 {
+			t.Errorf("Map size should be 0 after clearing, got %d", s.size())
+		}
+	})
 }

--- a/analyticsservice/safe_seen_targets_map.go
+++ b/analyticsservice/safe_seen_targets_map.go
@@ -20,11 +20,8 @@ func newSafeSeenTargets(maxSize int) SafeSeenTargetsCache[string, bool] {
 	}
 }
 
-func (s *safeSeenTargets) setWithLimit(key string, seen bool) {
-	if s.limitExceeded.Load() {
-		return
-	}
-
+// The regular set method just calls SetWithLimit
+func (s *safeSeenTargets) set(key string, seen bool) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -34,11 +31,6 @@ func (s *safeSeenTargets) setWithLimit(key string, seen bool) {
 	}
 
 	s.data[key] = seen
-}
-
-// The regular set method just calls SetWithLimit
-func (s *safeSeenTargets) set(key string, seen bool) {
-	s.setWithLimit(key, seen)
 }
 
 func (s *safeSeenTargets) get(key string) (bool, bool) {

--- a/analyticsservice/safe_seen_targets_map.go
+++ b/analyticsservice/safe_seen_targets_map.go
@@ -45,6 +45,7 @@ func (s *safeSeenTargets) setWithLimit(key string, seen bool) {
 
 	if len(s.data) >= s.maxSize {
 		s.limitExceeded.Store(true)
+		return
 	}
 
 	s.data[key] = seen

--- a/analyticsservice/safe_seen_targets_map.go
+++ b/analyticsservice/safe_seen_targets_map.go
@@ -2,23 +2,57 @@ package analyticsservice
 
 import (
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type safeSeenTargets struct {
 	sync.RWMutex
-	data map[string]bool
+	data          map[string]bool
+	maxSize       int
+	limitExceeded atomic.Bool
+	clearingTimer *time.Ticker
 }
 
-func newSafeSeenTargets() SafeAnalyticsCache[string, bool] {
-	return &safeSeenTargets{
-		data: make(map[string]bool),
+// Implements SafeSeenTargetsCache
+func newSafeSeenTargets(maxSize int, clearingInterval time.Duration) SafeSeenTargetsCache[string, bool] {
+	st := &safeSeenTargets{
+		data:    make(map[string]bool),
+		maxSize: maxSize,
 	}
+
+	if clearingInterval > 0 {
+		st.clearingTimer = time.NewTicker(clearingInterval)
+
+		// Start a goroutine to clear the cache at a set interval
+		go func() {
+			for range st.clearingTimer.C {
+				st.clear()
+			}
+		}()
+	}
+
+	return st
 }
 
-func (s *safeSeenTargets) set(key string, seen bool) {
+func (s *safeSeenTargets) setWithLimit(key string, seen bool) {
+	if s.limitExceeded.Load() {
+		return
+	}
+
 	s.Lock()
 	defer s.Unlock()
+
+	if len(s.data) >= s.maxSize {
+		s.limitExceeded.Store(true)
+	}
+
 	s.data[key] = seen
+}
+
+// The regular set method just calls SetWithLimit
+func (s *safeSeenTargets) set(key string, seen bool) {
+	s.setWithLimit(key, seen)
 }
 
 func (s *safeSeenTargets) get(key string) (bool, bool) {
@@ -44,6 +78,7 @@ func (s *safeSeenTargets) clear() {
 	s.Lock()
 	defer s.Unlock()
 	s.data = make(map[string]bool)
+	s.limitExceeded.Store(false)
 }
 
 func (s *safeSeenTargets) iterate(f func(string, bool)) {
@@ -52,4 +87,8 @@ func (s *safeSeenTargets) iterate(f func(string, bool)) {
 	for key, value := range s.data {
 		f(key, value)
 	}
+}
+
+func (s *safeSeenTargets) isLimitExceeded() bool {
+	return s.limitExceeded.Load()
 }

--- a/analyticsservice/safe_seen_targets_map.go
+++ b/analyticsservice/safe_seen_targets_map.go
@@ -3,7 +3,6 @@ package analyticsservice
 import (
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
 type safeSeenTargets struct {
@@ -11,28 +10,14 @@ type safeSeenTargets struct {
 	data          map[string]bool
 	maxSize       int
 	limitExceeded atomic.Bool
-	clearingTimer *time.Ticker
 }
 
 // Implements SafeSeenTargetsCache
-func newSafeSeenTargets(maxSize int, clearingInterval time.Duration) SafeSeenTargetsCache[string, bool] {
-	st := &safeSeenTargets{
+func newSafeSeenTargets(maxSize int) SafeSeenTargetsCache[string, bool] {
+	return &safeSeenTargets{
 		data:    make(map[string]bool),
 		maxSize: maxSize,
 	}
-
-	if clearingInterval > 0 {
-		st.clearingTimer = time.NewTicker(clearingInterval)
-
-		// Start a goroutine to clear the cache at a set interval
-		go func() {
-			for range st.clearingTimer.C {
-				st.clear()
-			}
-		}()
-	}
-
-	return st
 }
 
 func (s *safeSeenTargets) setWithLimit(key string, seen bool) {

--- a/analyticsservice/safe_seen_targets_map.go
+++ b/analyticsservice/safe_seen_targets_map.go
@@ -12,7 +12,6 @@ type safeSeenTargets struct {
 	limitExceeded atomic.Bool
 }
 
-// Implements SafeSeenTargetsCache
 func newSafeSeenTargets(maxSize int) SafeSeenTargetsCache[string, bool] {
 	return &safeSeenTargets{
 		data:    make(map[string]bool),
@@ -20,7 +19,6 @@ func newSafeSeenTargets(maxSize int) SafeSeenTargetsCache[string, bool] {
 	}
 }
 
-// The regular set method just calls SetWithLimit
 func (s *safeSeenTargets) set(key string, seen bool) {
 	s.Lock()
 	defer s.Unlock()

--- a/client/client.go
+++ b/client/client.go
@@ -79,7 +79,7 @@ func NewCfClient(sdkKey string, options ...ConfigOption) (*CfClient, error) {
 		opt(config)
 	}
 
-	analyticsService := analyticsservice.NewAnalyticsService(time.Minute, config.Logger)
+	analyticsService := analyticsservice.NewAnalyticsService(time.Minute, config.Logger, config.seenTargetsMaxSize, config.seenTargetsClearInterval)
 
 	client := &CfClient{
 		sdkKey:                 sdkKey,

--- a/client/config.go
+++ b/client/config.go
@@ -18,26 +18,28 @@ import (
 )
 
 type config struct {
-	url                    string
-	eventsURL              string
-	pullInterval           uint // in seconds
-	Cache                  cache.Cache
-	Store                  storage.Storage
-	Logger                 logger.Logger
-	httpClient             *http.Client
-	authHttpClient         *http.Client
-	enableStream           bool
-	enableStore            bool
-	target                 evaluation.Target
-	eventStreamListener    stream.EventStreamListener
-	enableAnalytics        bool
-	proxyMode              bool
-	waitForInitialized     bool
-	maxAuthRetries         int
-	authRetryStrategy      *backoff.ExponentialBackOff
-	streamingRetryStrategy *backoff.ExponentialBackOff
-	sleeper                types.Sleeper
-	apiConfig              *apiConfiguration
+	url                      string
+	eventsURL                string
+	pullInterval             uint // in seconds
+	Cache                    cache.Cache
+	Store                    storage.Storage
+	Logger                   logger.Logger
+	httpClient               *http.Client
+	authHttpClient           *http.Client
+	enableStream             bool
+	enableStore              bool
+	target                   evaluation.Target
+	eventStreamListener      stream.EventStreamListener
+	enableAnalytics          bool
+	proxyMode                bool
+	waitForInitialized       bool
+	maxAuthRetries           int
+	authRetryStrategy        *backoff.ExponentialBackOff
+	streamingRetryStrategy   *backoff.ExponentialBackOff
+	sleeper                  types.Sleeper
+	apiConfig                *apiConfiguration
+	seenTargetsMaxSize       int
+	seenTargetsClearInterval time.Duration
 }
 
 type apiConfiguration struct {
@@ -87,24 +89,25 @@ func newDefaultConfig(log logger.Logger) *config {
 	}
 
 	return &config{
-		url:             "https://config.ff.harness.io/api/1.0",
-		eventsURL:       "https://events.ff.harness.io/api/1.0",
-		pullInterval:    60,
-		Cache:           defaultCache,
-		Store:           defaultStore,
-		Logger:          log,
-		authHttpClient:  authHttpClient,
-		httpClient:      requestHttpClient.StandardClient(),
-		enableStream:    true,
-		enableStore:     true,
-		enableAnalytics: true,
-		proxyMode:       false,
-		// Indicate that we should retry forever by default
-		maxAuthRetries:         -1,
-		authRetryStrategy:      getDefaultExpBackoff(),
-		streamingRetryStrategy: getDefaultExpBackoff(),
-		sleeper:                &types.RealClock{},
-		apiConfig:              apiConfig,
+		url:                      "https://config.ff.harness.io/api/1.0",
+		eventsURL:                "https://events.ff.harness.io/api/1.0",
+		pullInterval:             60,
+		Cache:                    defaultCache,
+		Store:                    defaultStore,
+		Logger:                   log,
+		authHttpClient:           authHttpClient,
+		httpClient:               requestHttpClient.StandardClient(),
+		enableStream:             true,
+		enableStore:              true,
+		enableAnalytics:          true,
+		proxyMode:                false,
+		maxAuthRetries:           -1, // Indicate that we should retry forever by default
+		authRetryStrategy:        getDefaultExpBackoff(),
+		streamingRetryStrategy:   getDefaultExpBackoff(),
+		sleeper:                  &types.RealClock{},
+		apiConfig:                apiConfig,
+		seenTargetsMaxSize:       500000,
+		seenTargetsClearInterval: 24 * time.Hour,
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -156,7 +156,8 @@ func WithSeenTargetsMaxSize(maxSize int) ConfigOption {
 	}
 }
 
-// WithSeenTargetsClearInterval sets the clearing interval for the seen targets map.
+// WithSeenTargetsClearInterval sets the clearing interval for the seen targets map. By default, the interval
+// is set to 24 hours.
 func WithSeenTargetsClearInterval(interval time.Duration) ConfigOption {
 	return func(config *config) {
 		config.seenTargetsClearInterval = interval

--- a/client/options.go
+++ b/client/options.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/harness/ff-golang-server-sdk/cache"
 	"github.com/harness/ff-golang-server-sdk/evaluation"
@@ -8,7 +11,6 @@ import (
 	"github.com/harness/ff-golang-server-sdk/storage"
 	"github.com/harness/ff-golang-server-sdk/stream"
 	"github.com/harness/ff-golang-server-sdk/types"
-	"net/http"
 )
 
 // ConfigOption is used as return value for advanced client configuration
@@ -140,5 +142,23 @@ func WithAuthRetryStrategy(retryStrategy *backoff.ExponentialBackOff) ConfigOpti
 func WithSleeper(sleeper types.Sleeper) ConfigOption {
 	return func(config *config) {
 		config.sleeper = sleeper
+	}
+}
+
+// WithSeenTargetsMaxSize sets the maximum size for the seen targets map.
+// The SeenTargetsCache helps to reduce the size of the analytics payload that the SDK sends to the Feature Flags Service.
+// This method allows you to set the maximum number of unique targets that will be stored in the SeenTargets cache.
+// By default, the limit is set to 500,000 unique targets. You can increase this number if you need to handle more than
+// 500,000 targets, which will reduce the payload size but will also increase memory usage.
+func WithSeenTargetsMaxSize(maxSize int) ConfigOption {
+	return func(config *config) {
+		config.seenTargetsMaxSize = maxSize
+	}
+}
+
+// WithSeenTargetsClearInterval sets the clearing interval for the seen targets map.
+func WithSeenTargetsClearInterval(interval time.Duration) ConfigOption {
+	return func(config *config) {
+		config.seenTargetsClearInterval = interval
 	}
 }

--- a/evaluation/util.go
+++ b/evaluation/util.go
@@ -80,7 +80,7 @@ func isEnabled(target *Target, bucketBy string, percentage int) bool {
 		if value == "" {
 			return false
 		}
-		log.Warnf("%s BucketBy attribute not found in target attributes, falling back to 'identifier': missing=%s, using value=%s", sdk_codes.MissingBucketBy, bucketBy, value)
+		log.Debugf("%s BucketBy attribute not found in target attributes, falling back to 'identifier': missing=%s, using value=%s", sdk_codes.MissingBucketBy, bucketBy, value)
 		bucketBy = "identifier"
 	}
 


### PR DESCRIPTION
# What
- Adds a configurable limit, defaulting to 500k targets, to `seenTargets`.  
- Adds a configurable clearing schedule, defaulting to 24 hours, to `seenTargets` 
- Change bucketBy missing attribute log from `warn` to `debug` 

# Why
To provide a sensible default upper bound for this map. 

# Testing
- New unit tests for size and clearing behaviour
- Manual smoke test  
